### PR TITLE
fix: avoid nuxtContext in spa mode

### DIFF
--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -16,7 +16,7 @@ const myPlugin = context => {
     context.beforeNuxtRender(({ nuxtState }) => {
       nuxtState.pinia = getRootState(context.req)
     })
-  } else {
+  } else if (context.nuxtState) {
     setStateProvider(() => context.nuxtState.pinia)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/posva/pinia/issues/161

Not calling the `setStateProvider()` in case of missing nuxtContext seems like a safer approach, otherwise it errored out on undefined state provider in some next step.