### PR TITLE
fix #179: check that `ssrContext` exists before setting

### DIFF
--- a/src/ssrPlugin.ts
+++ b/src/ssrPlugin.ts
@@ -20,7 +20,7 @@ export const PiniaSsr = (vue: VueConstructor) => {
         // @ts-ignore
         this.$options.setup = (props: any, context: SetupContext) => {
           // @ts-ignore
-          setActiveReq(context.ssrContext.req)
+          if (context.ssrContext) setActiveReq(context.ssrContext.req)
           return setup(props, context)
         }
       }


### PR DESCRIPTION
closes #179

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It was a concealed issue as the `if (setup)` meant the code wasn't being run in Nuxt, but when `nuxt-composition-api` set the global `setup` function, the code was then being run.