### PR TITLE
feat: access the state and getters through `this`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ There are the core principles that I try to achieve with this experiment:
 
 - Flat modular structure 🍍 No nesting, only stores, compose them as needed
 - Light layer on top of Vue 💨 keep it very lightweight
-- Only `state`, `getters` 👐 `patch` is the new _mutation_
+- Only `state`, `getters`
+- No more verbose mutations, 👐 `patch` is _the mutation_
 - Actions are like _methods_ ⚗️ Group your business there
 - Import what you need, let webpack code split 📦 No need for dynamically registered modules
 - SSR support ⚙️
@@ -131,8 +132,8 @@ export default defineComponent({
     return {
       // gives access to the whole store
       main,
-      // gives access only to the state
-      state: computed(() => main.state),
+      // gives access only to specific state
+      state: computed(() => main.counter),
       // gives access to specific getter; like `computed` properties
       doubleCount: computed(() => main.doubleCount),
     }
@@ -215,7 +216,8 @@ The `main` store in an object wrapped with `reactive`, meaning there is no need 
 ```ts
 export default defineComponent({
   setup() {
-    // ❌ This won't work, it breaks reactivity
+    // ❌ This won't work because it breaks reactivity
+    // it's the same as destructuring from `props`
     const { name, doubleCount } = useMainStore()
     return { name, doubleCount }
   },

--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -1,6 +1,6 @@
 import { createStore, setActiveReq } from '../src'
 
-describe('Store', () => {
+describe('Actions', () => {
   const useStore = () => {
     // create a new store
     setActiveReq({})

--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -13,9 +13,20 @@ describe('Actions', () => {
           a: { b: 'string' },
         },
       }),
+      getters: {
+        nonA(): boolean {
+          return !this.a
+        },
+        otherComputed() {
+          return this.nonA
+        },
+      },
       actions: {
+        async getNonA() {
+          return this.nonA
+        },
         toggle() {
-          this.state.a = !this.state.a
+          return (this.a = !this.a)
         },
 
         setFoo(foo: string) {

--- a/__tests__/getters.spec.ts
+++ b/__tests__/getters.spec.ts
@@ -1,6 +1,6 @@
 import { createStore, setActiveReq } from '../src'
 
-describe('Store', () => {
+describe('Getters', () => {
   const useStore = () => {
     // create a new store
     setActiveReq({})
@@ -35,15 +35,15 @@ describe('Store', () => {
 
   it('adds getters to the store', () => {
     const store = useStore()
-    expect(store.upperCaseName.value).toBe('EDUARDO')
+    expect(store.upperCaseName).toBe('EDUARDO')
     store.state.name = 'Ed'
-    expect(store.upperCaseName.value).toBe('ED')
+    expect(store.upperCaseName).toBe('ED')
   })
 
   it('updates the value', () => {
     const store = useStore()
     store.state.name = 'Ed'
-    expect(store.upperCaseName.value).toBe('ED')
+    expect(store.upperCaseName).toBe('ED')
   })
 
   it('supports changing between requests', () => {
@@ -58,13 +58,13 @@ describe('Store', () => {
     bStore.state.b = 'c'
 
     aStore.state.a = 'b'
-    expect(aStore.fromB.value).toBe('b b')
+    expect(aStore.fromB).toBe('b b')
   })
 
   it('can use other getters', () => {
     const store = useStore()
-    expect(store.composed.value).toBe('EDUARDO: ok')
+    expect(store.composed).toBe('EDUARDO: ok')
     store.state.name = 'Ed'
-    expect(store.composed.value).toBe('ED: ok')
+    expect(store.composed).toBe('ED: ok')
   })
 })

--- a/__tests__/getters.spec.ts
+++ b/__tests__/getters.spec.ts
@@ -10,9 +10,18 @@ describe('Getters', () => {
         name: 'Eduardo',
       }),
       getters: {
-        upperCaseName: ({ name }) => name.toUpperCase(),
-        composed: (state, { upperCaseName }) =>
-          (upperCaseName.value as string) + ': ok',
+        upperCaseName() {
+          return this.name.toUpperCase()
+        },
+        doubleName() {
+          return this.upperCaseName
+        },
+        composed() {
+          return this.upperCaseName + ': ok'
+        },
+        // TODO: I can't figure out how to pass `this` as an argument. Not sure
+        // it is possible in this specific scenario
+        // upperCaseNameArrow: store => store.name,
       },
     })()
   }
@@ -26,9 +35,9 @@ describe('Getters', () => {
     id: 'A',
     state: () => ({ a: 'a' }),
     getters: {
-      fromB(state) {
+      fromB() {
         const bStore = useB()
-        return state.a + ' ' + bStore.state.b
+        return this.a + ' ' + bStore.b
       },
     },
   })
@@ -36,13 +45,13 @@ describe('Getters', () => {
   it('adds getters to the store', () => {
     const store = useStore()
     expect(store.upperCaseName).toBe('EDUARDO')
-    store.state.name = 'Ed'
+    store.name = 'Ed'
     expect(store.upperCaseName).toBe('ED')
   })
 
   it('updates the value', () => {
     const store = useStore()
-    store.state.name = 'Ed'
+    store.name = 'Ed'
     expect(store.upperCaseName).toBe('ED')
   })
 
@@ -55,16 +64,16 @@ describe('Getters', () => {
     // simulate a different request
     setActiveReq(req2)
     const bStore = useB()
-    bStore.state.b = 'c'
+    bStore.b = 'c'
 
-    aStore.state.a = 'b'
+    aStore.a = 'b'
     expect(aStore.fromB).toBe('b b')
   })
 
   it('can use other getters', () => {
     const store = useStore()
     expect(store.composed).toBe('EDUARDO: ok')
-    store.state.name = 'Ed'
+    store.name = 'Ed'
     expect(store.composed).toBe('ED: ok')
   })
 })

--- a/__tests__/rootState.spec.ts
+++ b/__tests__/rootState.spec.ts
@@ -1,6 +1,6 @@
 import { createStore, getRootState } from '../src'
 
-describe('Store', () => {
+describe('Root State', () => {
   const useA = createStore({
     id: 'a',
     state: () => ({ a: 'a' }),

--- a/__tests__/state.spec.ts
+++ b/__tests__/state.spec.ts
@@ -1,4 +1,5 @@
 import { createStore, setActiveReq } from '../src'
+import { computed } from '@vue/composition-api'
 
 describe('State', () => {
   const useStore = () => {
@@ -16,9 +17,15 @@ describe('State', () => {
   it('can directly access state at the store level', () => {
     const store = useStore()
     expect(store.name).toBe('Eduardo')
-    store.state.name = 'Ed'
+    store.name = 'Ed'
     expect(store.name).toBe('Ed')
   })
 
-  it.todo('state is reactive')
+  it('state is reactive', () => {
+    const store = useStore()
+    const upperCased = computed(() => store.name.toUpperCase())
+    expect(upperCased.value).toBe('EDUARDO')
+    store.name = 'Ed'
+    expect(upperCased.value).toBe('ED')
+  })
 })

--- a/__tests__/state.spec.ts
+++ b/__tests__/state.spec.ts
@@ -1,0 +1,24 @@
+import { createStore, setActiveReq } from '../src'
+
+describe('State', () => {
+  const useStore = () => {
+    // create a new store
+    setActiveReq({})
+    return createStore({
+      id: 'main',
+      state: () => ({
+        name: 'Eduardo',
+        counter: 0,
+      }),
+    })()
+  }
+
+  it('can directly access state at the store level', () => {
+    const store = useStore()
+    expect(store.name).toBe('Eduardo')
+    store.state.name = 'Ed'
+    expect(store.name).toBe('Ed')
+  })
+
+  it.todo('state is reactive')
+})

--- a/__tests__/tds/store.test-d.ts
+++ b/__tests__/tds/store.test-d.ts
@@ -5,12 +5,16 @@ const useStore = createStore({
   id: 'name',
   state: () => ({ a: 'on' as 'on' | 'off' }),
   getters: {
-    upper: state => state.a.toUpperCase(),
+    upper() {
+      return this.a.toUpperCase()
+    },
   },
 })
 
 const store = useStore()
 
 expectType<{ a: 'on' | 'off' }>(store.state)
+
+expectType<{ upper: string }>(store)
 
 expectError(() => store.nonExistant)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { createStore } from './store'
 export { setActiveReq, setStateProvider, getRootState } from './rootStore'
-export { StateTree, StoreGetter, Store } from './types'
+export { StateTree, Store } from './types'
 export { PiniaSsr } from './ssrPlugin'

--- a/src/ssrPlugin.ts
+++ b/src/ssrPlugin.ts
@@ -19,7 +19,7 @@ export const PiniaSsr = (vue: VueConstructor) => {
       if (setup) {
         // @ts-ignore
         this.$options.setup = (props: any, context: SetupContext) => {
-          // @ts-ignore
+          // @ts-ignore to fix usage with nuxt-composition-api https://github.com/posva/pinia/issues/179
           if (context.ssrContext) setActiveReq(context.ssrContext.req)
           return setup(props, context)
         }

--- a/src/ssrPlugin.ts
+++ b/src/ssrPlugin.ts
@@ -2,7 +2,7 @@ import { VueConstructor } from 'vue/types'
 import { setActiveReq } from './rootStore'
 import { SetupContext } from '@vue/composition-api'
 
-export const PiniaSsr = (vue: VueConstructor) => {
+export const PiniaSsr = (_Vue: VueConstructor) => {
   const isServer = typeof window === 'undefined'
 
   if (!isServer) {
@@ -12,14 +12,14 @@ export const PiniaSsr = (vue: VueConstructor) => {
     return
   }
 
-  vue.mixin({
+  _Vue.mixin({
     beforeCreate() {
       // @ts-ignore
       const { setup, serverPrefetch } = this.$options
       if (setup) {
         // @ts-ignore
         this.$options.setup = (props: any, context: SetupContext) => {
-          // @ts-ignore to fix usage with nuxt-composition-api https://github.com/posva/pinia/issues/179
+          // @ts-ignore TODO: fix usage with nuxt-composition-api https://github.com/posva/pinia/issues/179
           if (context.ssrContext) setActiveReq(context.ssrContext.req)
           return setup(props, context)
         }

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,7 +8,6 @@ import {
   StoreWithGetters,
   Store,
   StoreWithActions,
-  StoreWithGettersValues,
   Method,
 } from './types'
 import { useStoreDevtools } from './devtools'
@@ -140,13 +139,13 @@ export function buildStore<
     reset,
   }
 
-  const computedGetters: StoreWithGetters<S, G> = {} as StoreWithGetters<S, G>
+  const computedGetters: StoreWithGetters<G> = {} as StoreWithGetters<G>
   for (const getterName in getters) {
     computedGetters[getterName] = computed(() => {
       setActiveReq(_r)
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       return getters[getterName].call(store, store)
-    }) as StoreWithGetters<S, G>[typeof getterName]
+    }) as StoreWithGetters<G>[typeof getterName]
   }
 
   // const reactiveGetters = reactive(computedGetters)
@@ -183,10 +182,9 @@ export function createStore<
 >(options: {
   id: Id
   state?: () => S
-  getters?: G & ThisType<S & StoreWithGettersValues<G>>
+  getters?: G & ThisType<S & StoreWithGetters<G>>
   // allow actions use other actions
-  actions?: A &
-    ThisType<A & S & StoreWithState<Id, S> & StoreWithGettersValues<G>>
+  actions?: A & ThisType<A & S & StoreWithState<Id, S> & StoreWithGetters<G>>
 }) {
   const { id, state, getters, actions } = options
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,7 +54,10 @@ function toComputed<T>(refObject: Ref<T>) {
   }
   for (const key in refObject.value) {
     // @ts-ignore: the key matches
-    reactiveObject[key] = computed(() => refObject.value[key as keyof T])
+    reactiveObject[key] = computed({
+      get: () => refObject.value[key as keyof T],
+      set: value => (refObject.value[key as keyof T] = value),
+    })
   }
 
   return reactiveObject

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface StoreWithState<Id extends string, S extends StateTree> {
 }
 
 export type Method = (...args: any[]) => any
+
 // export type StoreAction<P extends any[], R> = (...args: P) => R
 // export interface StoreAction<P, R> {
 //   (...args: P[]): R
@@ -75,40 +76,24 @@ export type StoreWithActions<A> = {
     : never
 }
 
-export interface StoreGetter<S extends StateTree, T = any> {
-  // TODO: would be nice to be able to define the getters here
-  (state: S, getters: Record<string, Ref<any>>): T
-}
+// export interface StoreGetter<S extends StateTree, T = any> {
+//   // TODO: would be nice to be able to define the getters here
+//   (state: S, getters: Record<string, Ref<any>>): T
+// }
 
-export type StoreWithGetters<
-  S extends StateTree,
-  G extends Record<string, StoreGetter<S>>
-> = {
-  [k in keyof G]: G[k] extends StoreGetter<S, infer V> ? Ref<V> : never
-}
-
-export interface StoreGetter<S extends StateTree, T = any> {
-  // TODO: would be nice to be able to define the getters here
-  (state: S, getters: Record<string, Ref<any>>): T
-}
-
-export interface StoreGetterThis {
-  (store?: any): any
-}
-
-export type StoreWithGettersValues<G> = {
+export type StoreWithGetters<G> = {
   [k in keyof G]: G[k] extends (this: infer This, store?: any) => infer R
     ? R
     : never
 }
 
-// in this type we forget about this because otherwise the type is recursive
-export type StoreWithThisGetters<G> = {
-  // TODO: does the infer this as the second argument work?
-  [k in keyof G]: G[k] extends (this: infer This, store?: any) => infer R
-    ? (this: This, store?: This) => R
-    : never
-}
+// // in this type we forget about this because otherwise the type is recursive
+// export type StoreWithThisGetters<G> = {
+//   // TODO: does the infer this as the second argument work?
+//   [k in keyof G]: G[k] extends (this: infer This, store?: any) => infer R
+//     ? (this: This, store?: This) => R
+//     : never
+// }
 
 // has the actions without the context (this) for typings
 export type Store<
@@ -116,11 +101,7 @@ export type Store<
   S extends StateTree,
   G,
   A
-> = StoreWithState<Id, S> &
-  S &
-  StoreWithGettersValues<G> &
-  // StoreWithGetters<S, G> &
-  StoreWithActions<A>
+> = StoreWithState<Id, S> & S & StoreWithGetters<G> & StoreWithActions<A>
 
 export type GenericStore = Store<
   string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface StoreWithState<Id extends string, S extends StateTree> {
   /**
    * State of the Store
    */
+  // TODO: remove
   state: S
 
   /**
@@ -91,7 +92,7 @@ export type Store<
   S extends StateTree,
   G extends Record<string, StoreGetter<S>>,
   A extends Record<string, StoreAction>
-> = StoreWithState<Id, S> & StoreWithGetters<S, G> & StoreWithActions<A>
+> = StoreWithState<Id, S> & S & StoreWithGetters<S, G> & StoreWithActions<A>
 
 export type GenericStore = Store<
   string,


### PR DESCRIPTION

- Removes the need of writing `.state` in `this.state.name = 'eduardo'`: `this.name = 'Eduardo'`
- Removes the need of using `.value` for getters

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
