### PR TITLE
fix: only set state provider if a state exists

### DIFF
--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -16,7 +16,7 @@ const myPlugin = context => {
     context.beforeNuxtRender(({ nuxtState }) => {
       nuxtState.pinia = getRootState(context.req)
     })
-  } else if (context.nuxtState) {
+  } else if (context.nuxtState && context.nuxtState.pinia) {
     setStateProvider(() => context.nuxtState.pinia)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/posva/pinia/issues/206

At some point, Nuxt started to have `context.nuxtState` even in SPA mode so the previous check was not enough.
Maybe there's a smarter way to check for SPA mode of Nuxt, but I'm not aware of it.