### PR TITLE
fix: resilient _VUE_DEVTOOLS_TOAST_ 

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -19,9 +19,9 @@ function toastMessage(
   message: string,
   type?: 'normal' | 'error' | 'warning' | undefined
 ) {
-  const piniaMessage = '🍍' + message
+  const piniaMessage = '🍍 ' + message
 
-  if (typeof __VUE_DEVTOOLS_TOAST__ !== 'undefined') {
+  if (typeof __VUE_DEVTOOLS_TOAST__ === 'function') {
     __VUE_DEVTOOLS_TOAST__(piniaMessage, type)
   } else if (type === 'error') {
     console.error(piniaMessage)

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,21 +15,20 @@ function formatDisplay(display: string) {
   }
 }
 
-function outputMessage(
+function toastMessage(
   message: string,
   type?: 'normal' | 'error' | 'warning' | undefined
 ) {
-  if (__VUE_DEVTOOLS_TOAST__) {
-    __VUE_DEVTOOLS_TOAST__(message, type)
-    return
-  }
+  const piniaMessage = '🍍' + message
 
-  if (type === 'error') {
-    console.error(message)
+  if (typeof __VUE_DEVTOOLS_TOAST__ !== 'undefined') {
+    __VUE_DEVTOOLS_TOAST__(piniaMessage, type)
+  } else if (type === 'error') {
+    console.error(piniaMessage)
   } else if (type === 'warning') {
-    console.warn(message)
+    console.warn(piniaMessage)
   } else {
-    console.log(message)
+    console.log(piniaMessage)
   }
 }
 
@@ -134,7 +133,7 @@ export function addDevtools(app: App, store: GenericStore) {
               options: formatStoreForInspectorState(store),
             }
           } else {
-            outputMessage(`🍍 store "${payload.nodeId}" not found`, 'error')
+            toastMessage(`store "${payload.nodeId}" not found`, 'error')
           }
         }
       })
@@ -142,7 +141,7 @@ export function addDevtools(app: App, store: GenericStore) {
       // trigger an update so it can display new registered stores
       // @ts-ignore
       api.notifyComponentUpdate()
-      outputMessage(`🍍 "${store.$id}" store installed`)
+      toastMessage(`"${store.$id}" store installed`)
     }
   )
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,6 +15,24 @@ function formatDisplay(display: string) {
   }
 }
 
+function outputMessage(
+  message: string,
+  type?: 'normal' | 'error' | 'warning' | undefined
+) {
+  if (__VUE_DEVTOOLS_TOAST__) {
+    __VUE_DEVTOOLS_TOAST__(message, type)
+    return
+  }
+
+  if (type === 'error') {
+    console.error(message)
+  } else if (type === 'warning') {
+    console.warn(message)
+  } else {
+    console.log(message)
+  }
+}
+
 let isAlreadyInstalled: boolean | undefined
 
 export function addDevtools(app: App, store: GenericStore) {
@@ -116,10 +134,7 @@ export function addDevtools(app: App, store: GenericStore) {
               options: formatStoreForInspectorState(store),
             }
           } else {
-            __VUE_DEVTOOLS_TOAST__(
-              `🍍 store "${payload.nodeId}" not found`,
-              'error'
-            )
+            outputMessage(`🍍 store "${payload.nodeId}" not found`, 'error')
           }
         }
       })
@@ -127,7 +142,7 @@ export function addDevtools(app: App, store: GenericStore) {
       // trigger an update so it can display new registered stores
       // @ts-ignore
       api.notifyComponentUpdate()
-      __VUE_DEVTOOLS_TOAST__(`🍍 "${store.$id}" store installed`)
+      outputMessage(`🍍 "${store.$id}" store installed`)
     }
   )
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included


**Other information:**
When using Pinia v2 with the latest beta of Vue devtools, I always experience the following console error:

```
backend.js:3166 ReferenceError: __VUE_DEVTOOLS_TOAST__ is not defined
    at pinia.esm-bundler.js?v=94b0b286:232
    at Object.addPlugin (backend.js:3162)
    at Object.<anonymous> (backend.js:908)
    at Object.emit (<anonymous>:1:780)
    at Object._replayBuffer (<anonymous>:1:332)
    at Object.on (<anonymous>:1:424)
    at connect (backend.js:907)
```

While I cannot exactly pin down the exact cause of this, I think its reasonable to fall back to console output whenever the devtools's toast is not available