### PR TITLE
docs: fixed naming for reference to other store in action

### DIFF
--- a/docs/core-concepts/actions.md
+++ b/docs/core-concepts/actions.md
@@ -37,7 +37,7 @@ export default defineComponent({
 To use another store, you can directly _use it_ inside of the _getter_:
 
 ```js
-import { useOtherStore } from './other-store'
+import { useAuthStore } from './auth-store'
 
 export const useSettingsStore = defineStore({
   id: 'settings',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: I was reading trough the docs, and under *Accessing other stores actions* the code provided is:

```js
import { useOtherStore } from './other-store'

export const useSettingsStore = defineStore({
  id: 'settings',
  state: () => ({
    // ...
  }),
  actions: {
    async fetchUserPreferences(preferences) {
      const auth = useAuthStore()
      if (auth.isAuthenticated) {
        this.preferences = await fetchPreferences()
      } else {
        throw new Error('User must be authenticated')
      }
    },
  },
})
```

The example lacks the definition of `useAuthStore`, while I guess it's supposed to be what is referenced in the import as `useOtherStore`.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
