### PR TITLE
feat(devtools): work with stores added before app.use

### DIFF
--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -1,4 +1,4 @@
-import { App, InjectionKey, Plugin, Ref, ref, warn } from 'vue'
+import { App, InjectionKey, Plugin, Ref, ref, warn, watch } from 'vue'
 import { IS_CLIENT } from './env'
 import {
   StateTree,
@@ -53,8 +53,23 @@ export const storesMap = new WeakMap<
  * Client-side application instance used for devtools
  */
 export let clientApp: App | undefined /*#__PURE__*/
-export const setClientApp = (app: App) => (clientApp = app)
-export const getClientApp = () => clientApp
+export const isClientAppReady = ref(false)
+export const setClientApp = (app: App) => {
+  clientApp = app
+  isClientAppReady.value = true
+}
+let promise: Promise<App> | undefined
+export const getClientApp = () => {
+  promise =
+    promise ||
+    new Promise((resolve) => {
+      watch(
+        () => isClientAppReady.value,
+        (val: boolean) => val && resolve(clientApp as App)
+      )
+    })
+  return promise
+}
 
 /**
  * Plugin to extend every store

--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -1,4 +1,4 @@
-import { App, InjectionKey, Plugin, Ref, ref, warn, watch } from 'vue'
+import { App, InjectionKey, Plugin, Ref, ref, warn } from 'vue'
 import { IS_CLIENT } from './env'
 import {
   StateTree,
@@ -53,23 +53,16 @@ export const storesMap = new WeakMap<
  * Client-side application instance used for devtools
  */
 export let clientApp: App | undefined /*#__PURE__*/
-export const isClientAppReady = ref(false)
+let promise: Promise<App> | undefined
+let resolveApp: Function | undefined
 export const setClientApp = (app: App) => {
   clientApp = app
-  isClientAppReady.value = true
+  ;(resolveApp as Function)(app)
 }
-let promise: Promise<App> | undefined
-export const getClientApp = () => {
-  promise =
-    promise ||
-    new Promise((resolve) => {
-      watch(
-        () => isClientAppReady.value,
-        (val: boolean) => val && resolve(clientApp as App)
-      )
-    })
-  return promise
-}
+export const getClientApp = () =>
+  clientApp
+    ? Promise.resolve(clientApp)
+    : promise || (promise = new Promise((resolve) => (resolveApp = resolve)))
 
 /**
  * Plugin to extend every store

--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -52,17 +52,12 @@ export const storesMap = new WeakMap<
 /**
  * Client-side application instance used for devtools
  */
-export let clientApp: App | undefined /*#__PURE__*/
 let promise: Promise<App> | undefined
 let resolveApp: Function | undefined
-export const setClientApp = (app: App) => {
-  clientApp = app
-  ;(resolveApp as Function)(app)
-}
+export const setClientApp = (app: App) =>
+  resolveApp && (resolveApp as Function)(app)
 export const getClientApp = () =>
-  clientApp
-    ? Promise.resolve(clientApp)
-    : promise || (promise = new Promise((resolve) => (resolveApp = resolve)))
+  promise || (promise = new Promise((resolve) => (resolveApp = resolve)))
 
 /**
  * Plugin to extend every store

--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -50,7 +50,7 @@ export const storesMap = new WeakMap<
 >()
 
 /**
- * Client-side application instance used for devtools
+ * Expose the client-side application instance used for devtools
  */
 let promise: Promise<App> | undefined
 let resolveApp: Function | undefined

--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -52,12 +52,12 @@ export const storesMap = new WeakMap<
 /**
  * Expose the client-side application instance used for devtools
  */
-let promise: Promise<App> | undefined
-let resolveApp: Function | undefined
-export const setClientApp = (app: App) =>
-  resolveApp && (resolveApp as Function)(app)
+let clientAppPromise: Promise<App> | undefined
+let resolveApp: ((app: App) => void) | undefined
+export const setClientApp = (app: App) => resolveApp && resolveApp(app)
 export const getClientApp = () =>
-  promise || (promise = new Promise((resolve) => (resolveApp = resolve)))
+  clientAppPromise ||
+  (clientAppPromise = new Promise((resolve) => (resolveApp = resolve)))
 
 /**
  * Plugin to extend every store

--- a/src/store.ts
+++ b/src/store.ts
@@ -253,9 +253,6 @@ function buildStoreToUse<
   return store
 }
 
-// only warn the dev once
-let isDevWarned: boolean | undefined
-
 /**
  * Creates a `useStore` function that retrieves the store instance
  * @param options - options to define the store
@@ -298,20 +295,7 @@ export function defineStore<
         __BROWSER__ &&
         __DEV__ /*|| __FEATURE_PROD_DEVTOOLS__*/
       ) {
-        const app = getClientApp()
-        /* istanbul ignore else */
-        if (app) {
-          addDevtools(app, store)
-        } else if (!isDevWarned && !__TEST__) {
-          isDevWarned = true
-          console.warn(
-            `[🍍]: store was instantiated before calling\n` +
-              `app.use(pinia)\n` +
-              `Make sure to install pinia's plugin by using createPinia:\n` +
-              `https://github.com/posva/pinia/tree/v2#install-the-plugin\n` +
-              `It will enable devtools and overall a better developer experience.`
-          )
-        }
+        getClientApp().then((app) => addDevtools(app, store))
       }
 
       return store


### PR DESCRIPTION
This removes the need to call `app.use(pinia)` BEFORE registering all services.  Services registered before calling the plugin are now held by a promise until the `app` object is set by the plugin.  The code used to set and get the `app` object for the devtools to work has been updated.  

As noted in the checkboxes, below, I haven't added any tests for this.  I did copy the built version into my Vite app to test. The app I'm testing has three stores that register before the app is created and five that register afterward.  Here's what I noticed from these changes:

- [x] Stores registered both before and after `app.use(pinia)` display properly in the devtools.
- [x] No extra logging occurs
- [x] No errors occur
- [x] Each store's data is browseable.

Summary of changes:
- convert getClientApp() to return a promise.  The promise resolves when the app is set (and a boolean ref gets set to true)
- Removes logging and warning state related to registering stores before calling app.use(pinia)

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature
**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number) **not applicable**
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature: Nobody will ask you for this feature in the future.  ;)
