### PR TITLE
feat: allow strict option

### DIFF
--- a/__tests__/strictMode.spec.ts
+++ b/__tests__/strictMode.spec.ts
@@ -1,0 +1,31 @@
+import { createPinia, defineStore, setActivePinia } from '../src'
+
+describe('Strict mode', () => {
+  const useStore = defineStore({
+    id: 'main',
+    strict: true,
+    state: () => ({
+      a: true,
+      nested: {
+        foo: 'foo',
+        a: { b: 'string' },
+      },
+    }),
+  })
+
+  it('cannot change the state directly', () => {
+    setActivePinia(createPinia())
+    const store = useStore()
+    // @ts-expect-error
+    store.a = false
+    // @ts-expect-error
+    store.nested.foo = 'bar'
+
+    // TODO: should direct $state be allowed?
+    // this could be an escape hatch if we want one
+    store.$state.a = false
+
+    store.$patch({ a: false })
+    store.$patch({ nested: { foo: 'bar' } })
+  })
+})

--- a/src/rootStore.ts
+++ b/src/rootStore.ts
@@ -120,7 +120,8 @@ export interface PiniaPluginContext<
   Id extends string = string,
   S extends StateTree = StateTree,
   G extends GettersTree<S> = GettersTree<S>,
-  A /* extends ActionsTree */ = ActionsTree
+  A /* extends ActionsTree */ = ActionsTree,
+  Strict extends boolean = false
 > {
   /**
    * pinia instance.
@@ -140,7 +141,7 @@ export interface PiniaPluginContext<
   /**
    * Current store being extended.
    */
-  options: DefineStoreOptions<Id, S, G, A>
+  options: DefineStoreOptions<Id, S, G, A, Strict>
 }
 
 /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -276,14 +276,15 @@ function buildStoreToUse<
   Id extends string,
   S extends StateTree,
   G extends GettersTree<S>,
-  A extends ActionsTree
+  A extends ActionsTree,
+  Strict extends boolean
 >(
   partialStore: StoreWithState<Id, S, G, A>,
   descriptor: StateDescriptor<S>,
   $id: Id,
   getters: G = {} as G,
   actions: A = {} as A,
-  options: DefineStoreOptions<Id, S, G, A>
+  options: DefineStoreOptions<Id, S, G, A, Strict>
 ) {
   const pinia = getActivePinia()
 
@@ -337,7 +338,7 @@ function buildStoreToUse<
     } as StoreWithActions<A>[typeof actionName]
   }
 
-  const store: Store<Id, S, G, A> = reactive(
+  const store: Store<Id, S, G, A, Strict> = reactive(
     assign(
       {},
       partialStore,
@@ -346,7 +347,7 @@ function buildStoreToUse<
       computedGetters,
       wrappedActions
     )
-  ) as Store<Id, S, G, A>
+  ) as Store<Id, S, G, A, Strict>
 
   // use this instead of a computed with setter to be able to create it anywhere
   // without linking the computed lifespan to wherever the store is first
@@ -375,11 +376,14 @@ export function defineStore<
   S extends StateTree,
   G extends GettersTree<S>,
   // cannot extends ActionsTree because we loose the typings
-  A /* extends ActionsTree */
->(options: DefineStoreOptions<Id, S, G, A>): StoreDefinition<Id, S, G, A> {
+  A /* extends ActionsTree */,
+  Strict extends boolean
+>(
+  options: DefineStoreOptions<Id, S, G, A, Strict>
+): StoreDefinition<Id, S, G, A, Strict> {
   const { id, state, getters, actions } = options
 
-  function useStore(pinia?: Pinia | null): Store<Id, S, G, A> {
+  function useStore(pinia?: Pinia | null): Store<Id, S, G, A, Strict> {
     const hasInstance = getCurrentInstance()
     // only run provide when pinia hasn't been manually passed
     const shouldProvide = hasInstance && !pinia
@@ -395,7 +399,7 @@ export function defineStore<
       | [
           StoreWithState<Id, S, G, A>,
           StateDescriptor<S>,
-          InjectionKey<Store<Id, S, G, A>>
+          InjectionKey<Store<Id, S, G, A, Strict>>
         ]
       | undefined
     if (!storeAndDescriptor) {
@@ -409,7 +413,8 @@ export function defineStore<
         S,
         G,
         // @ts-expect-error: A without extends
-        A
+        A,
+        Strict
       >(
         storeAndDescriptor[0],
         storeAndDescriptor[1],
@@ -436,7 +441,8 @@ export function defineStore<
         S,
         G,
         // @ts-expect-error: A without extends
-        A
+        A,
+        Strict
       >(
         storeAndDescriptor[0],
         storeAndDescriptor[1],

--- a/test-dts/customizations.test-d.ts
+++ b/test-dts/customizations.test-d.ts
@@ -7,11 +7,11 @@ declare module '../dist/pinia' {
     suffix: 'Store'
   }
 
-  export interface PiniaCustomProperties<Id, S, G, A> {
+  export interface PiniaCustomProperties<Id, S, G, A, Strict> {
     $actions: Array<keyof A>
   }
 
-  export interface DefineStoreOptions<Id, S, G, A> {
+  export interface DefineStoreOptions<Id, S, G, A, Strict> {
     debounce?: {
       // Record<keyof A, number>
       [k in keyof A]?: number

--- a/test-dts/plugins.test-d.ts
+++ b/test-dts/plugins.test-d.ts
@@ -3,6 +3,7 @@ import {
   expectType,
   createPinia,
   GenericStore,
+  Store,
   Pinia,
   StateTree,
   DefineStoreOptions,
@@ -12,6 +13,7 @@ const pinia = createPinia()
 
 pinia.use(({ store, app, options, pinia }) => {
   expectType<GenericStore>(store)
+  expectType<Store>(store)
   expectType<Pinia>(pinia)
   expectType<App>(app)
   expectType<
@@ -19,7 +21,8 @@ pinia.use(({ store, app, options, pinia }) => {
       string,
       StateTree,
       Record<string, any>,
-      Record<string, any>
+      Record<string, any>,
+      boolean
     >
   >(options)
 })


### PR DESCRIPTION
Close #58

This still needs work, it's more of an experiment yet. Feel free to pick it up and move forward or propose API ideas

So far:

- Make `store.aStateProperty` readonly
- Allow changes in actions
- Allow changes to `store.$state`
- Allow calls to `store.$patch()` anywhere


A runtime check could be added in dev mode only as well
