### PR TITLE
docs: add store destructure guide

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -39,7 +39,7 @@ If you are not using `setup` components yet, [you can still use Pinia with _map 
 
 Once the store is instantiated, you can access any property defined in `state`, `getters`, and `actions` directly on the store. We will see these in detail in the next pages but autocompletion will help you.
 
-Note that `store` is an object wrapped with `reactive`, meaning there is no need to write `.value` after getters but, like `props` in `setup`, **we cannot destructure it**:
+Note that `store` is an object wrapped with `reactive`, meaning there is no need to write `.value` after getters but, like `props` in `setup`, **we cannot destructure it directly**:
 
 ```js
 export default defineComponent({
@@ -60,6 +60,25 @@ export default defineComponent({
       // this one will be reactive
       doubleValue: computed(() => store.doubleCount),
       }
+  },
+})
+```
+
+You can use `storeToRefs` to destructure the returned object without losing reactivity:
+```js
+import { storeToRefs } from 'pinia'
+
+export default defineComponent({
+  setup() {
+    const store = useStore()
+    // Now name & doubleCount still have reactivity
+    // Note that methods and non reactive properties will be ignored
+    const { name, doubleCount } = storeToRefs(store)
+
+    return {
+      name,
+      doubleCount
+    }
   },
 })
 ```

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -39,7 +39,7 @@ If you are not using `setup` components yet, [you can still use Pinia with _map 
 
 Once the store is instantiated, you can access any property defined in `state`, `getters`, and `actions` directly on the store. We will see these in detail in the next pages but autocompletion will help you.
 
-Note that `store` is an object wrapped with `reactive`, meaning there is no need to write `.value` after getters but, like `props` in `setup`, **we cannot destructure it directly**:
+Note that `store` is an object wrapped with `reactive`, meaning there is no need to write `.value` after getters but, like `props` in `setup`, **we cannot destructure it**:
 
 ```js
 export default defineComponent({
@@ -64,15 +64,16 @@ export default defineComponent({
 })
 ```
 
-You can use `storeToRefs` to destructure the returned object without losing reactivity:
+In order to extract properties from the store while keeping its reactivity, you need to use `storeToRefs()`. It will create refs for any reactive property. This is useful when you are only using state from the store but not calling any action:
 ```js
 import { storeToRefs } from 'pinia'
 
 export default defineComponent({
   setup() {
     const store = useStore()
-    // Now name & doubleCount still have reactivity
-    // Note that methods and non reactive properties will be ignored
+    // `name` and `doubleCount` are reactive refs
+    // This will also create refs for properties added by plugins
+    // but skip any action or non reactive (non ref/reactive) property
     const { name, doubleCount } = storeToRefs(store)
 
     return {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Docs update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I found that there is a method `storeToRefs` in the source code, but didn't saw it in docs.
So I think it's good to put it in store guide.