### PR TITLE
feat(docs): add action example in setup mode

### DIFF
--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -55,8 +55,9 @@ You can even use a function (similar to a component `setup()`) to define a Store
 ```js
 export const useCounterStore = defineStore('counter', () => {
   const count = ref(0)
+  const increment = () => count.value++
 
-  return { count }
+  return { count, increment }
 })
 ```
 

--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -31,6 +31,11 @@ export const useCounterStore = defineStore('counter', {
   },
   // could also be defined as
   // state: () => ({ count: 0 })
+  actions: {
+    increment() {
+      this.count++
+    }
+  }
 })
 ```
 
@@ -46,6 +51,8 @@ export default {
     counter.count++
     // with autocompletion ✨
     counter.$patch({ count: counter.count + 1 })
+    // using the action
+    coutner.increment();
   },
 }
 ```

--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -51,7 +51,7 @@ export default {
     counter.count++
     // with autocompletion ✨
     counter.$patch({ count: counter.count + 1 })
-    // using the action
+    // or using an action instead
     coutner.increment();
   },
 }
@@ -62,7 +62,9 @@ You can even use a function (similar to a component `setup()`) to define a Store
 ```js
 export const useCounterStore = defineStore('counter', () => {
   const count = ref(0)
-  const increment = () => count.value++
+  function increment() {
+    count.value++
+  }
 
   return { count, increment }
 })


### PR DESCRIPTION
As a first time user, a lot of things that are now obvious were not to me. Like the fact that you don't need to call `this.$patch` inside actions in setup mode.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
