### PR TITLE
feat(warn): log store id with class constructor warning

### DIFF
--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -335,38 +335,35 @@ describe('Store', () => {
   })
 
   const warnTextCheckPlainObject = (storeId: string) =>
-    `"state" for ${storeId} must be a plain object`
+    `The "state" must be a plain object. It cannot be\n\tstate: () => new MyClass()\nFound in store "${storeId}".`
 
   it('warns when state is created with a class constructor', () => {
     class MyState {}
 
-    const id = 'store'
     const useMyStore = defineStore({
-      id,
+      id: 'store',
       state: () => new MyState(),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject(id)).toHaveBeenWarned()
+    expect(warnTextCheckPlainObject('store')).toHaveBeenWarned()
   })
 
   it('only warns about constructors when store is initially created', () => {
     class MyState {}
-    const id = 'arrowInit'
     const useMyStore = defineStore({
-      id,
+      id: 'arrowInit',
       state: () => new MyState(),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject(id)).toHaveBeenWarnedTimes(1)
+    expect(warnTextCheckPlainObject('arrowInit')).toHaveBeenWarnedTimes(1)
   })
 
   it('does not warn when state is created with a plain object', () => {
-    const id = 'poInit'
     const useMyStore = defineStore({
-      id,
+      id: 'poInit',
       state: () => ({ someValue: undefined }),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject(id)).toHaveBeenWarnedTimes(0)
+    expect(warnTextCheckPlainObject('poInit')).toHaveBeenWarnedTimes(0)
   })
 })

--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -334,35 +334,39 @@ describe('Store', () => {
     expect(useStore()).not.toBe(store)
   })
 
-  const warnTextCheckPlainObject = `"state" must be a plain object`
+  const warnTextCheckPlainObject = (storeId: string) =>
+    `"state" for ${storeId} must be a plain object`
 
   it('warns when state is created with a class constructor', () => {
     class MyState {}
 
+    const id = 'store'
     const useMyStore = defineStore({
-      id: 'store',
+      id,
       state: () => new MyState(),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject).toHaveBeenWarned()
+    expect(warnTextCheckPlainObject(id)).toHaveBeenWarned()
   })
 
   it('only warns about constructors when store is initially created', () => {
     class MyState {}
+    const id = 'arrowInit'
     const useMyStore = defineStore({
-      id: 'arrowInit',
+      id,
       state: () => new MyState(),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject).toHaveBeenWarnedTimes(1)
+    expect(warnTextCheckPlainObject(id)).toHaveBeenWarnedTimes(1)
   })
 
   it('does not warn when state is created with a plain object', () => {
+    const id = 'poInit'
     const useMyStore = defineStore({
-      id: 'poInit',
+      id,
       state: () => ({ someValue: undefined }),
     })
     useMyStore()
-    expect(warnTextCheckPlainObject).toHaveBeenWarnedTimes(0)
+    expect(warnTextCheckPlainObject(id)).toHaveBeenWarnedTimes(0)
   })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -676,7 +676,7 @@ function createSetupStore<
     !store.$state.constructor.toString().includes('[native code]')
   ) {
     console.warn(
-      `[🍍]: The "state" must be a plain object. It cannot be\n\tstate: () => new MyClass()`
+      `[🍍]: The "state" for ${store.$id} must be a plain object. It cannot be\n\tstate: () => new MyClass()`
     )
   }
 

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -676,7 +676,7 @@ function createSetupStore<
     !store.$state.constructor.toString().includes('[native code]')
   ) {
     console.warn(
-      `[🍍]: The "state" for ${store.$id} must be a plain object. It cannot be\n\tstate: () => new MyClass()`
+      `[🍍]: The "state" must be a plain object. It cannot be\n\tstate: () => new MyClass()\nFound in store "${store.$id}".`
     )
   }
 


### PR DESCRIPTION
We were using class constructors to create state in some of our stores, thought it would be helpful to include the store id in the log to that it would be easier to spot which stores need to be converted to plain objects.
