### PR TITLE
docs: Fix typo

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -40,7 +40,7 @@ new Vue({
 })
 ```
 
-This will also add devtools support. In Vue 3, some features like time traveling and editing are still not supported because vue-devtools doesn't expose the necessary APIs yet but the devtools have way more features are the developer experience as a whole is far superior. In Vue 2, Pinia uses the existing interface for Vuex (and can therefore not be used alongside it).
+This will also add devtools support. In Vue 3, some features like time traveling and editing are still not supported because vue-devtools doesn't expose the necessary APIs yet but the devtools have way more features and the developer experience as a whole is far superior. In Vue 2, Pinia uses the existing interface for Vuex (and can therefore not be used alongside it).
 
 ## What is a Store?
 


### PR DESCRIPTION
It's a minor (and the only) typo on the `getting started` page.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
