### PR TITLE
docs: fix import `useUserStore`

### DIFF
--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -94,7 +94,7 @@ The same applies to _actions_:
 
 ```js
 import { defineStore } from 'pinia'
-import { useCartStore } from './cart'
+import { useUserStore } from './user'
 
 export const useCartStore = defineStore('cart', {
   actions: {


### PR DESCRIPTION
The [Shared Actions](https://pinia.esm.dev/cookbook/composing-stores.html#shared-actions) example was importing `useCartStore` instead of `useUserStore`.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
