### PR TITLE
docs: module import for createTestingPinia from  @pinia/testing

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -76,7 +76,7 @@ And make sure to create a testing pinia in your tests when mounting a component:
 
 ```js
 import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/nuxt'
+import { createTestingPinia } from '@pinia/testing'
 
 const wrapper = mount(Counter, {
   global: {


### PR DESCRIPTION
I assume this was a typo, or am I being crazy here? 

I changed the nuxt part into testing.

import { createTestingPinia } from '@pinia/nuxt'

Hope this helps.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
