### PR TITLE
Only add explicit nuxt alias for nuxt3

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -28,10 +28,6 @@ const module = defineNuxtModule<PiniaNuxtOptions>({
       nuxt.options.features.store = false
     }
 
-    // make sure we use the mjs for pinia so node doesn't complain about using a module js with an extension that is js
-    // but doesn't have the type: module in its packages.json file
-    nuxt.options.alias.pinia = 'pinia/dist/pinia.mjs'
-
     addPlugin({ src: require.resolve('./plugin.mjs') })
 
     // transpile pinia for nuxt 2 and nuxt bridge


### PR DESCRIPTION
The explicit nuxt alias leads to problems with nuxt/bridge (using vite) as descirbed here https://github.com/posva/pinia/issues/690#issuecomment-956913149.
I'm not completely sure why this alias was added in the first place. Since `pinia` is added to `build.transpile` anyway, the es module build shouldn't be used anyway.

Reverts https://github.com/posva/pinia/commit/438b16dfd3dd5052be437d2e7382f9f4f497eea3
Fixes #690.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
