### PR TITLE
fix(nuxt): plugin path was escaped

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -36,7 +36,7 @@ export default <Module>function (_options) {
   // but doesn't have the type: module in its packages.json file
   nuxt.options.alias.pinia = 'pinia/dist/pinia.mjs'
 
-  this.addPlugin({ src: require.resolve('./plugin.mjs') })
+  this.addPlugin({ src: require.resolve('./plugin.mjs').replace(/\\/g,'/') })
 
   // transpile pinia for nuxt 2 and nuxt bridge
   if (isVue2 && !nuxt.options.build.transpile.includes('pinia')) {


### PR DESCRIPTION
Use in Nuxt3 has error 🤔
```
 WARN  [SSR] Error transforming virtual:D:/Git/GitHub/vitesse-nuxt3/.nuxt/plugins/server.mjs: Error: Failed to resolve import "D:GitGitHub
                                                                                                                                          itesse-nuxt3                                                          17:54:51
ode_modules@pinia
uxtdistplugin.mjs" from "virtual:D:\Git\GitHub\vitesse-nuxt3\.nuxt\plugins\server.mjs". Does the file exist?
```

https://github.com/posva/pinia/blob/bfd53c813e2241bd8cac282f89a85382a02eca85/packages/nuxt/src/module.ts#L38-L40

```ts
  this.addPlugin({ src: require.resolve('./plugin.mjs') })
  // require.resolve('./plugin.mjs') -> 'D:\Git\GitHub\vitesse-nuxt3\node_modules\@pinia\nuxt\dist\plugin.mjs   '
```

`"\n"` was escaped as a newline character
```
"D:GitGitHub
                                                                                                                                          itesse-nuxt3
ode_modules@pinia
uxtdistplugin.mjs"
```
