### PR TITLE
docs: fix typo in testing.md

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -104,4 +104,4 @@ You can find more examples in [the tests of the testing package](https://github.
 
 ## E2E tests
 
-When it comes to pinia, you don't need to change anything for e2e tests, that's the whole point of e2e tests! You could maybe tests HTTP requests, but that's way beyond the scope of this guide 😄.
+When it comes to pinia, you don't need to change anything for e2e tests, that's the whole point of e2e tests! You could maybe test HTTP requests, but that's way beyond the scope of this guide 😄.


### PR DESCRIPTION
Didn't include a test, since this is a docs update.