### PR TITLE
docs: fix typo in actions.md

### DIFF
--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -27,7 +27,7 @@ const api = mande('/api/users')
 
 export const useUsers = defineStore('users', {
   state: () => ({
-    data: userData,
+    userData: null,
     // ...
   }),
 


### PR DESCRIPTION
small update to the actions docs - the action further down refers to a state property which doesn't exist