### PR TITLE
refactor(types): set gereric for state

### DIFF
--- a/packages/pinia/src/createPinia.ts
+++ b/packages/pinia/src/createPinia.ts
@@ -1,5 +1,5 @@
 import { Pinia, PiniaPlugin, setActivePinia, piniaSymbol } from './rootStore'
-import { ref, App, markRaw, effectScope, isVue2 } from 'vue-demi'
+import { ref, App, markRaw, effectScope, isVue2, Ref } from 'vue-demi'
 import { registerPiniaDevtools, devtoolsPlugin } from './devtools'
 import { IS_CLIENT } from './env'
 import { StateTree, StoreGeneric } from './types'
@@ -11,7 +11,9 @@ export function createPinia(): Pinia {
   const scope = effectScope(true)
   // NOTE: here we could check the window object for a state and directly set it
   // if there is anything like it with Vue 3 SSR
-  const state = scope.run(() => ref<Record<string, StateTree>>({}))!
+  const state = scope.run<Ref<Record<string, StateTree>>>(() =>
+    ref<Record<string, StateTree>>({})
+  )!
 
   let _p: Pinia['_p'] = []
   // plugins added before calling app.use(pinia)


### PR DESCRIPTION
we should set generic for state so that state wont loose type

In Vue, effect run's type has a generic input and return the same generic
so, if not set genric, state's type will like:
![image](https://user-images.githubusercontent.com/24717511/146880801-f613d057-cd28-4f08-a5ed-b591b7b7a5b7.png)

so if we set generic, state's type will not loose:
![image](https://user-images.githubusercontent.com/24717511/146880883-8bae9c90-6df7-47af-9702-26adbe2e6721.png)



