### PR TITLE
feat(types): support IDE features for store context

### DIFF
--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -546,31 +546,43 @@ export type _ActionsTree = Record<string, _Method>
 /**
  * @internal
  */
+declare type _ExtractStateFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends _Method | ComputedRef ? never : K]: any }
+
+/**
+ * @internal
+ */
+declare type _ExtractActionsFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends _Method ? K : never]: any }
+
+/**
+ * @internal
+ */
+declare type _ExtractGettersFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends ComputedRef ? K : never]: any }
+
+/**
+ * @internal
+ */
+declare type _UnwrapAll<SS> = { [K in keyof SS]: UnwrapRef<SS[K]> }
+
+/**
+ * @internal
+ */
 export type _ExtractStateFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : {
-      [K in keyof SS as SS[K] extends _Method | ComputedRef
-        ? never
-        : K]: UnwrapRef<SS[K]>
-    }
+  : _ExtractStateFromSetupStore_Keys<SS> extends keyof SS ? _UnwrapAll<Pick<SS, _ExtractStateFromSetupStore_Keys<SS>>> : never
 
 /**
  * @internal
  */
 export type _ExtractActionsFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : {
-      [K in keyof SS as SS[K] extends _Method ? K : never]: SS[K]
-    }
+  : _ExtractActionsFromSetupStore_Keys<SS> extends keyof SS ? Pick<SS, _ExtractActionsFromSetupStore_Keys<SS>> : never;
 
 /**
  * @internal
  */
 export type _ExtractGettersFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : {
-      [K in keyof SS as SS[K] extends ComputedRef ? K : never]: UnwrapRef<SS[K]>
-    }
+  : _ExtractGettersFromSetupStore_Keys<SS> extends keyof SS ? _UnwrapAll<Pick<SS, _ExtractGettersFromSetupStore_Keys<SS>>> : never;
 
 /**
  * Options passed to `defineStore()` that are common between option and setup

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -546,17 +546,23 @@ export type _ActionsTree = Record<string, _Method>
 /**
  * @internal
  */
-declare type _ExtractStateFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends _Method | ComputedRef ? never : K]: any }
+declare type _ExtractStateFromSetupStore_Keys<SS> = keyof {
+  [K in keyof SS as SS[K] extends _Method | ComputedRef ? never : K]: any
+}
 
 /**
  * @internal
  */
-declare type _ExtractActionsFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends _Method ? K : never]: any }
+declare type _ExtractActionsFromSetupStore_Keys<SS> = keyof {
+  [K in keyof SS as SS[K] extends _Method ? K : never]: any
+}
 
 /**
  * @internal
  */
-declare type _ExtractGettersFromSetupStore_Keys<SS> = keyof { [K in keyof SS as SS[K] extends ComputedRef ? K : never]: any }
+declare type _ExtractGettersFromSetupStore_Keys<SS> = keyof {
+  [K in keyof SS as SS[K] extends ComputedRef ? K : never]: any
+}
 
 /**
  * @internal
@@ -568,21 +574,27 @@ declare type _UnwrapAll<SS> = { [K in keyof SS]: UnwrapRef<SS[K]> }
  */
 export type _ExtractStateFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : _ExtractStateFromSetupStore_Keys<SS> extends keyof SS ? _UnwrapAll<Pick<SS, _ExtractStateFromSetupStore_Keys<SS>>> : never
+  : _ExtractStateFromSetupStore_Keys<SS> extends keyof SS
+  ? _UnwrapAll<Pick<SS, _ExtractStateFromSetupStore_Keys<SS>>>
+  : never
 
 /**
  * @internal
  */
 export type _ExtractActionsFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : _ExtractActionsFromSetupStore_Keys<SS> extends keyof SS ? Pick<SS, _ExtractActionsFromSetupStore_Keys<SS>> : never;
+  : _ExtractActionsFromSetupStore_Keys<SS> extends keyof SS
+  ? Pick<SS, _ExtractActionsFromSetupStore_Keys<SS>>
+  : never
 
 /**
  * @internal
  */
 export type _ExtractGettersFromSetupStore<SS> = SS extends undefined | void
   ? {}
-  : _ExtractGettersFromSetupStore_Keys<SS> extends keyof SS ? _UnwrapAll<Pick<SS, _ExtractGettersFromSetupStore_Keys<SS>>> : never;
+  : _ExtractGettersFromSetupStore_Keys<SS> extends keyof SS
+  ? _UnwrapAll<Pick<SS, _ExtractGettersFromSetupStore_Keys<SS>>>
+  : never
 
 /**
  * Options passed to `defineStore()` that are common between option and setup

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -546,28 +546,28 @@ export type _ActionsTree = Record<string, _Method>
 /**
  * @internal
  */
-declare type _ExtractStateFromSetupStore_Keys<SS> = keyof {
+type _ExtractStateFromSetupStore_Keys<SS> = keyof {
   [K in keyof SS as SS[K] extends _Method | ComputedRef ? never : K]: any
 }
 
 /**
  * @internal
  */
-declare type _ExtractActionsFromSetupStore_Keys<SS> = keyof {
+type _ExtractActionsFromSetupStore_Keys<SS> = keyof {
   [K in keyof SS as SS[K] extends _Method ? K : never]: any
 }
 
 /**
  * @internal
  */
-declare type _ExtractGettersFromSetupStore_Keys<SS> = keyof {
+type _ExtractGettersFromSetupStore_Keys<SS> = keyof {
   [K in keyof SS as SS[K] extends ComputedRef ? K : never]: any
 }
 
 /**
  * @internal
  */
-declare type _UnwrapAll<SS> = { [K in keyof SS]: UnwrapRef<SS[K]> }
+type _UnwrapAll<SS> = { [K in keyof SS]: UnwrapRef<SS[K]> }
 
 /**
  * @internal


### PR DESCRIPTION
Fixed:

```ts
const useFoo = defineStore('foo', () => ({ bar: 123 }));
const foo = useFoo();
foo.bar // <-- renaming, goto definition, find references not working for bar
```