### PR TITLE
fix(subscriptions): allow removing subscriptions inside them

### DIFF
--- a/packages/pinia/__tests__/subscriptions.spec.ts
+++ b/packages/pinia/__tests__/subscriptions.spec.ts
@@ -272,4 +272,33 @@ describe('Subscriptions', () => {
       store.$state
     )
   })
+
+  it('subscribe once with patch', () => {
+    const spy1 = jest.fn()
+    const spy2 = jest.fn()
+    const store = useStore()
+    function once() {
+      const unsubscribe = store.$subscribe(
+        () => {
+          spy1()
+          unsubscribe()
+        },
+        { flush: 'sync' }
+      )
+    }
+    once()
+    store.$subscribe(spy2, { flush: 'sync' })
+    expect(spy1).toHaveBeenCalledTimes(0)
+    expect(spy2).toHaveBeenCalledTimes(0)
+    store.$patch((state) => {
+      state.user = 'a'
+    })
+    expect(spy1).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledTimes(1)
+    store.$patch((state) => {
+      state.user = 'b'
+    })
+    expect(spy1).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/pinia/src/subscriptions.ts
+++ b/packages/pinia/src/subscriptions.ts
@@ -30,7 +30,7 @@ export function triggerSubscriptions<T extends _Method>(
   subscriptions: T[],
   ...args: Parameters<T>
 ) {
-  ;[...subscriptions].forEach((callback) => {
+  subscriptions.slice().forEach((callback) => {
     callback(...args)
   })
 }

--- a/packages/pinia/src/subscriptions.ts
+++ b/packages/pinia/src/subscriptions.ts
@@ -30,7 +30,7 @@ export function triggerSubscriptions<T extends _Method>(
   subscriptions: T[],
   ...args: Parameters<T>
 ) {
-  subscriptions.forEach((callback) => {
+  ;[...subscriptions].forEach((callback) => {
     callback(...args)
   })
 }


### PR DESCRIPTION
I'm sorry, my English is not very good. For a brief expression, I only used $subscribe once at that time, which will lead to exceptions in the subsequent $subscribe. I try to fix it in this way.