### PR TITLE
docs: clarify plugins don't update devtools timeline

### DIFF
--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -131,7 +131,7 @@ pinia.use(({ store }) => {
 })
 ```
 
-State changes that occur within a plugin are not recorded in the devtools timeline.
+Note that state changes or additions that occur within a plugin (that includes calling `store.$patch()`) happen before the store is active and therefore **do not trigger any subscriptions**.
 
 :::warning
 If you are using **Vue 2**, Pinia is subject to the [same reactivity caveats](https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats) as Vue. You will need to use `set` from `@vue/composition-api` when creating new state properties like `secret` and `hasError`:

--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -131,6 +131,8 @@ pinia.use(({ store }) => {
 })
 ```
 
+State changes that occur within a plugin are not recorded in the devtools timeline.
+
 :::warning
 If you are using **Vue 2**, Pinia is subject to the [same reactivity caveats](https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats) as Vue. You will need to use `set` from `@vue/composition-api` when creating new state properties like `secret` and `hasError`:
 


### PR DESCRIPTION
Related to issue: #996 