### PR TITLE
docs: add hint on destructuring actions from store

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -84,8 +84,7 @@ export default defineComponent({
 })
 ```
 
-:::warning
-Extracting `actions` using `storeToRefs` will result in `actions` being `undefined`. To extract `actions` from the store, you should skip using `storeToRefs`
+Extracting `actions` using `storeToRefs` will result in `actions` being `undefined`. To extract `actions` from the store, you should skip using `storeToRefs`:
 
 ```js
 import { storeToRefs } from 'pinia'
@@ -103,7 +102,7 @@ export default defineComponent({
     increment() // "undefined"
 
 
-    // if you want to only destructure `actions`
+    // ✅ if you want to only destructure `actions`
     // from the store then don't use `storeToRefs`
     const { increment } = store
 
@@ -111,17 +110,6 @@ export default defineComponent({
     counter // 2
 })
 ```
-:::
-
-:::tip
-- **To extract only the properties from the store:**
-    - `const { counter } = counterStore`
-
-<br/>
-
-- **To extract only the actions from the store:**
-    - `const { increment, decrement } = counterStore`
-:::
 
 
 

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -87,10 +87,41 @@ export default defineComponent({
 :::warning
 Extracting `actions` using `storeToRefs` will result in `actions` being `undefined`. To extract `actions` from the store, you should skip using `storeToRefs`
 
-```
-const store = useStore()
+```js
+import { storeToRefs } from 'pinia'
+import useCounterStore from '@/store/counter'
 
-const { fullName, age } = store
-const { logIn } = store
+export default defineComponent({
+    const store = useCounterStore()
+
+    const { counter, increment } = storeToRefs(store)
+
+    counter // 1
+
+    // ❌ This won't work because
+    // `storeToRefs` skips `actions` from the store
+    increment() // "undefined"
+
+
+    // if you want to only destructure `actions`
+    // from the store then don't use `storeToRefs`
+    const { increment } = store
+
+    increment() // works!
+    counter // 2
+})
 ```
 :::
+
+:::tip
+- **To extract only the properties from the store:**
+    - `const { counter } = counterStore`
+
+<br/>
+
+- **To extract only the actions from the store:**
+    - `const { increment, decrement } = counterStore`
+:::
+
+
+

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -83,3 +83,14 @@ export default defineComponent({
   },
 })
 ```
+
+:::warning
+Extracting `actions` using `storeToRefs` will result in `actions` being `undefined`. To extract `actions` from the store, you should skip using `storeToRefs`
+
+```
+const store = useStore()
+
+const { fullName, age } = store
+const { logIn } = store
+```
+:::


### PR DESCRIPTION
Added a warning section to hint the user on how to destructure `actions` from the `store`.