### PR TITLE
docs: clarify import store requirement in Options API usage

### DIFF
--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -105,15 +105,29 @@ export default {
 If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapActions()` helper to map actions properties as methods in your component:
 
 ```js
+// Example File Path:
+// src/stores/counterStore.js
+
+import { defineStore } from 'pinia',
+
+const useCounterStore = defineStore('counterStore', {
+  state: () => ({
+    counter: 0
+  })
+})
+```
+
+```js
 import { mapActions } from 'pinia'
+import { useCounterStore } from '../stores/counterStore'
 
 export default {
   methods: {
     // gives access to this.increment() inside the component
     // same as calling from store.increment()
-    ...mapActions(useStore, ['increment'])
+    ...mapActions(useCounterStore, ['increment'])
     // same as above but registers it as this.myOwnName()
-    ...mapActions(useStore, { myOwnName: 'doubleCounter' }),
+    ...mapActions(useCounterStore, { myOwnName: 'doubleCounter' }),
   },
 }
 ```

--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -124,7 +124,7 @@ const useCounterStore = defineStore('counterStore', {
 
 ### With `setup()`
 
-While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+While Composition API is not for everyone, the `setup()` hook can make using Pinia easier to work with in the Options API. No extra map helper functions needed!
 
 ```js
 import { useCounterStore } from '../stores/counterStore'

--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -100,9 +100,9 @@ export default {
 }
 ```
 
-## Usage with the options API
+## Usage with the Options API
 
-If you are not using the composition API, and you are using `computed`, `methods`, ..., you can use the `mapActions()` helper to map actions properties as methods in your component:
+If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapActions()` helper to map actions properties as methods in your component:
 
 ```js
 import { mapActions } from 'pinia'

--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -102,20 +102,51 @@ export default {
 
 ## Usage with the Options API
 
-If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapActions()` helper to map actions properties as methods in your component:
+For the following examples, we'll be assuming you've created the following store:
 
 ```js
 // Example File Path:
-// src/stores/counterStore.js
+// ./src/stores/counterStore.js
 
 import { defineStore } from 'pinia',
 
 const useCounterStore = defineStore('counterStore', {
   state: () => ({
     counter: 0
-  })
+  }),
+  actions: {
+    increment() {
+      this.counter++
+    }
+  }
 })
 ```
+
+### With `setup()`
+
+While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+
+```js
+import { useCounterStore } from '../stores/counterStore'
+
+export default {
+  setup() {
+    const counterStore = useCounterStore()
+
+    return { counterStore }
+  },
+  methods: {
+    incrementAndPrint() {
+      counterStore.increment()
+      console.log('New Count:', counterStore.count)
+    },
+  },
+}
+```
+
+### Without `setup()`
+
+If you would prefer not to use Composition API at all, you can use the `mapActions()` helper to map actions properties as methods in your component:
 
 ```js
 import { mapActions } from 'pinia'

--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -102,7 +102,7 @@ export default {
 
 ## Usage with the Options API
 
-For the following examples, we'll be assuming you've created the following store:
+For the following examples, you can assume the following store was created:
 
 ```js
 // Example File Path:

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -162,15 +162,29 @@ export default {
 You can use the same `mapState()` function used in the [previous section of state](./state.md#options-api) to map to getters:
 
 ```js
+// Example File Path:
+// src/stores/counterStore.js
+
+import { defineStore } from 'pinia',
+
+const useCounterStore = defineStore('counterStore', {
+  state: () => ({
+    counter: 0
+  })
+})
+```
+
+```js
 import { mapState } from 'pinia'
+import { useCounterStore } from '../stores/counterStore'
 
 export default {
   computed: {
     // gives access to this.doubleCounter inside the component
     // same as reading from store.doubleCounter
-    ...mapState(useStore, ['doubleCount'])
+    ...mapState(useCounterStore, ['doubleCount'])
     // same as above but registers it as this.myOwnName
-    ...mapState(useStore, {
+    ...mapState(useCounterStore, {
       myOwnName: 'doubleCounter',
       // you can also write a function that gets access to the store
       double: store => store.doubleCount,

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -79,7 +79,6 @@ export const useStore = defineStore('main', {
 })
 ```
 
-
 ## Passing arguments to getters
 
 _Getters_ are just _computed_ properties behind the scenes, so it's not possible to pass any parameters to them. However, you can return a function from the _getter_ to accept any arguments:
@@ -107,9 +106,7 @@ export default {
 }
 </script>
 
-<template>
-User 2: {{ getUserById(2) }}
-</template>
+<template>User 2: {{ getUserById(2) }}</template>
 ```
 
 Note that when doing this, **getters are not cached anymore**, they are simply functions that you invoke. You can however cache some results inside of the getter itself, which is uncommon but should prove more performant:
@@ -160,7 +157,7 @@ export default {
 }
 ```
 
-## Usage with the options API
+## Usage with the Options API
 
 You can use the same `mapState()` function used in the [previous section of state](./state.md#options-api) to map to getters:
 

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -159,20 +159,50 @@ export default {
 
 ## Usage with the Options API
 
-You can use the same `mapState()` function used in the [previous section of state](./state.md#options-api) to map to getters:
+For the following examples, we'll be assuming you've created the following store:
 
 ```js
 // Example File Path:
-// src/stores/counterStore.js
+// ./src/stores/counterStore.js
 
 import { defineStore } from 'pinia',
 
 const useCounterStore = defineStore('counterStore', {
   state: () => ({
     counter: 0
-  })
+  }),
+  getters: {
+    doubleCounter() {
+      return this.counter * 2
+    }
+  }
 })
 ```
+
+### With `setup()`
+
+While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+
+```js
+import { useCounterStore } from '../stores/counterStore'
+
+export default {
+  setup() {
+    const counterStore = useCounterStore()
+
+    return { counterStore }
+  },
+  computed: {
+    quadrupleCounter() {
+      return counterStore.doubleCounter * 2
+    },
+  },
+}
+```
+
+### Without `setup()`
+
+You can use the same `mapState()` function used in the [previous section of state](./state.md#options-api) to map to getters:
 
 ```js
 import { mapState } from 'pinia'

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -181,7 +181,7 @@ const useCounterStore = defineStore('counterStore', {
 
 ### With `setup()`
 
-While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+While Composition API is not for everyone, the `setup()` hook can make using Pinia easier to work with in the Options API. No extra map helper functions needed!
 
 ```js
 import { useCounterStore } from '../stores/counterStore'

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -106,7 +106,9 @@ export default {
 }
 </script>
 
-<template>User 2: {{ getUserById(2) }}</template>
+<template>
+  <p>User 2: {{ getUserById(2) }}</p>
+</template>
 ```
 
 Note that when doing this, **getters are not cached anymore**, they are simply functions that you invoke. You can however cache some results inside of the getter itself, which is uncommon but should prove more performant:

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -106,9 +106,7 @@ export default {
 }
 </script>
 
-<template>
-User 2: {{ getUserById(2) }}
-</template>
+<template>User 2: {{ getUserById(2) }}</template>
 ```
 
 Note that when doing this, **getters are not cached anymore**, they are simply functions that you invoke. You can however cache some results inside of the getter itself, which is uncommon but should prove more performant:
@@ -161,7 +159,7 @@ export default {
 
 ## Usage with the Options API
 
-For the following examples, we'll be assuming you've created the following store:
+For the following examples, you can assume the following store was created:
 
 ```js
 // Example File Path:

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -106,7 +106,9 @@ export default {
 }
 </script>
 
-<template>User 2: {{ getUserById(2) }}</template>
+<template>
+User 2: {{ getUserById(2) }}
+</template>
 ```
 
 Note that when doing this, **getters are not cached anymore**, they are simply functions that you invoke. You can however cache some results inside of the getter itself, which is uncommon but should prove more performant:

--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -44,7 +44,7 @@ store.$reset()
 
 ### Usage with the Options API
 
-For the following examples, we'll be assuming you've created the following store:
+For the following examples, you can assume the following store was created:
 
 ```js
 // Example File Path:

--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -61,7 +61,7 @@ const useCounterStore = defineStore('counterStore', {
 
 ### With `setup()`
 
-While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+While Composition API is not for everyone, the `setup()` hook can make using Pinia easier to work with in the Options API. No extra map helper functions needed!
 
 ```js
 import { useCounterStore } from '../stores/counterStore'

--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -44,11 +44,11 @@ store.$reset()
 
 ### Usage with the Options API
 
-If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapState()` helper to map state properties as readonly computed properties:
+For the following examples, we'll be assuming you've created the following store:
 
 ```js
 // Example File Path:
-// src/stores/counterStore.js
+// ./src/stores/counterStore.js
 
 import { defineStore } from 'pinia',
 
@@ -58,6 +58,31 @@ const useCounterStore = defineStore('counterStore', {
   })
 })
 ```
+
+### With `setup()`
+
+While Composition API is not for everyone, the `setup()` hook makes using Pinia easier to work with in the Options API. No extra map helper functions needed!
+
+```js
+import { useCounterStore } from '../stores/counterStore'
+
+export default {
+  setup() {
+    const counterStore = useCounterStore()
+
+    return { counterStore }
+  },
+  computed: {
+    tripleCounter() {
+      return counterStore.counter * 3
+    },
+  },
+}
+```
+
+### Without `setup()`
+
+If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapState()` helper to map state properties as readonly computed properties:
 
 ```js
 import { mapState } from 'pinia'

--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -47,15 +47,29 @@ store.$reset()
 If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapState()` helper to map state properties as readonly computed properties:
 
 ```js
+// Example File Path:
+// src/stores/counterStore.js
+
+import { defineStore } from 'pinia',
+
+const useCounterStore = defineStore('counterStore', {
+  state: () => ({
+    counter: 0
+  })
+})
+```
+
+```js
 import { mapState } from 'pinia'
+import { useCounterStore } from '../stores/counterStore'
 
 export default {
   computed: {
     // gives access to this.counter inside the component
     // same as reading from store.counter
-    ...mapState(useStore, ['counter'])
+    ...mapState(useCounterStore, ['counter'])
     // same as above but registers it as this.myOwnName
-    ...mapState(useStore, {
+    ...mapState(useCounterStore, {
       myOwnName: 'counter',
       // you can also write a function that gets access to the store
       double: store => store.counter * 2,
@@ -74,15 +88,16 @@ If you want to be able to write to these state properties (e.g. if you have a fo
 
 ```js
 import { mapWritableState } from 'pinia'
+import { useCounterStore } from '../stores/counterStore'
 
 export default {
   computed: {
     // gives access to this.counter inside the component and allows setting it
     // this.counter++
     // same as reading from store.counter
-    ...mapWritableState(useStore, ['counter'])
+    ...mapWritableState(useCounterStore, ['counter'])
     // same as above but registers it as this.myOwnName
-    ...mapWritableState(useStore, {
+    ...mapWritableState(useCounterStore, {
       myOwnName: 'counter',
     }),
   },

--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -42,9 +42,9 @@ const store = useStore()
 store.$reset()
 ```
 
-### Usage with the options API
+### Usage with the Options API
 
-If you are not using the composition API, and you are using `computed`, `methods`, ..., you can use the `mapState()` helper to map state properties as readonly computed properties:
+If you are not using the Composition API, and you are using `computed`, `methods`, ..., you can use the `mapState()` helper to map state properties as readonly computed properties:
 
 ```js
 import { mapState } from 'pinia'


### PR DESCRIPTION
I was going through the docs and reviewing the Options API recommendations and realized there's a little bit of a disconnect between when stores are imported. So, rather than assume people can make the connection that the store is imported, I've added an explicit example to improve users' ability to figure out what comes from where.