### PR TITLE
docs: typo in migration-vuex.md

### DIFF
--- a/packages/docs/cookbook/migration-vuex.md
+++ b/packages/docs/cookbook/migration-vuex.md
@@ -31,8 +31,8 @@ src
 └── stores
     ├── index.js          # (Optional) Initializes Pinia, does not import stores
     ├── module1.js        # 'module1' id
-    ├── nested-module2.js # 'nested/module3' id
-    ├── nested-module3.js # 'nested/module2' id
+    ├── nested-module2.js # 'nested/module2' id
+    ├── nested-module3.js # 'nested/module3' id
     └── nested.js         # 'nested' id
 ```
 


### PR DESCRIPTION
This is a simple typo fix for the migration-vuex docs page.