### PR TITLE
Update hot-module-replacement.md

### DIFF
--- a/packages/docs/cookbook/hot-module-replacement.md
+++ b/packages/docs/cookbook/hot-module-replacement.md
@@ -14,7 +14,7 @@ const useAuth = defineStore('auth', {
 })
 
 // make sure to pass the right store definition, `useAuth` in this case.
-if (import.meta.hot) {
-  import.meta.hot.accept(acceptHMRUpdate(useAuth, import.meta.hot))
+if (module.hot) {
+  module.hot.accept(acceptHMRUpdate(useAuth, module.hot))
 }
 ```


### PR DESCRIPTION
`import meta.hot` is raising a JS syntax error. The `module.hot` syntax is working.
