### PR TITLE
docs: move preferences from parameter to state

### DIFF
--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -76,10 +76,11 @@ import { useAuthStore } from './auth-store'
 
 export const useSettingsStore = defineStore('settings', {
   state: () => ({
+    preferences: null,
     // ...
   }),
   actions: {
-    async fetchUserPreferences(preferences) {
+    async fetchUserPreferences() {
       const auth = useAuthStore()
       if (auth.isAuthenticated) {
         this.preferences = await fetchPreferences()


### PR DESCRIPTION
- Move the `preferences` parameter passed to `fetchUserPreferences` to `state` so that `this.preferences` in the function makes sense.
