### PR TITLE
docs: fix options api syntax

### DIFF
--- a/packages/docs/cookbook/options-api.md
+++ b/packages/docs/cookbook/options-api.md
@@ -27,8 +27,7 @@ export default {
   computed: {
     // note we are not passing an array, just one store after the other
     // each store will be accessible as its id + 'Store'
-    ...mapStores(useCartStore, useUserStore),
-    }),
+    ...mapStores(useCartStore, useUserStore)
   },
 
   methods: {


### PR DESCRIPTION
Updated options api docs to remove extra closing brackets.