### PR TITLE
docs: update nuxt.js examples in plugins.md

### DIFF
--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -371,11 +371,8 @@ function MyPiniaPlugin({ store }: PiniaPluginContext) {
     console.log(`[🍍 ${mutation.storeId}]: ${mutation.type}.`)
   })
 
-  const creationTime = new Date();
-   
-  // add new state
-  store.$state.creationTime = creationTime;
-  store.secret.creationTime = creationTime;
+  // Note this has to be typed if you are using TS
+  return { creationTime: new Date() }
 }
 
 const myPlugin: Plugin = ({ $pinia }) => {

--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -371,12 +371,17 @@ function MyPiniaPlugin({ store }: PiniaPluginContext) {
     console.log(`[🍍 ${mutation.storeId}]: ${mutation.type}.`)
   })
 
-  return { creationTime: new Date() }
+  const creationTime = new Date();
+   
+  // add new state
+  store.$state.creationTime = creationTime;
+  store.secret.creationTime = creationTime;
 }
 
-const myPlugin: Plugin = ({ pinia }) {
-  pinia.use(MyPiniaPlugin);
+const myPlugin: Plugin = ({ $pinia }) => {
+  $pinia.use(MyPiniaPlugin);
 }
+
 export default myPlugin
 ```
 

--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -376,7 +376,7 @@ function MyPiniaPlugin({ store }: PiniaPluginContext) {
 }
 
 const myPlugin: Plugin = ({ $pinia }) => {
-  $pinia.use(MyPiniaPlugin);
+  $pinia.use(MyPiniaPlugin)
 }
 
 export default myPlugin


### PR DESCRIPTION
The `myPlugin` function was missing an arrow.
I also updated the way the `creationTime` property was added to the global state.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
