### PR TITLE
fix(testing): allow writable pinia getters in Vue 2

### DIFF
--- a/packages/testing/src/testing.ts
+++ b/packages/testing/src/testing.ts
@@ -197,17 +197,19 @@ function isComputed<T>(
   return !!v && isRef(v) && 'effect' in v
 }
 
-function WritableComputed({ store }: PiniaPluginContext) {
+function WritableComputed({ store, options }: PiniaPluginContext) {
   const rawStore = toRaw(store)
   for (const key in rawStore) {
     const value = rawStore[key]
-    if (isComputed(value)) {
+    // Vue2 store getters are not refs and can't be found with isComputed()
+    const isVue2Getter = isVue2 && options.getters?.[key]
+    if (isComputed(value) || isVue2Getter) {
       rawStore[key] = customRef((track, trigger) => {
         let internalValue: any
         return {
           get: () => {
             track()
-            return internalValue !== undefined ? internalValue : value.value
+            return internalValue !== undefined ? internalValue : (isVue2Getter ? value : value.value)
           },
           set: (newValue) => {
             internalValue = newValue


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

## Description:
This allows Pinia store getters in Vue 2 apps to be reassigned as shown in the [test here](https://github.com/vuejs/pinia/blob/6ce186f5acf50c0c4ece1aec6468534e0916e688/packages/testing/src/testing.spec.ts#L203). 

## Related Issues:
Close #1200 

## Testing Notes:
I wasn't able to write a test for this directly into the pinia/testing repo due to the fact that I would need to use the `vue-demi switch 2 vue2` npm script, which requires me to install vue/composition api, which then causes a number of peer dependency issues. I talk about this further in the Issue attached.

## Code Notes:
I'm not married to the nested ternary, and I don't know if there's a precedence for optional chaining, so I'm happy to adjust any of these.
