### PR TITLE
docs: fix typo in `PiniaPluginContext`

### DIFF
--- a/packages/docs/api/interfaces/pinia.PiniaPluginContext.md
+++ b/packages/docs/api/interfaces/pinia.PiniaPluginContext.md
@@ -39,7 +39,7 @@ ___
 
 • **options**: [`DefineStoreOptionsInPlugin`](pinia.DefineStoreOptionsInPlugin.md)<`Id`, `S`, `G`, `A`\>
 
-Current store being extended.
+Options object defining the store passed to `defineStore()`.
 
 #### Defined in
 

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -122,7 +122,7 @@ export interface PiniaPluginContext<
   store: Store<Id, S, G, A>
 
   /**
-   * Current store being extended.
+   * Options object defining the store passed to `defineStore()`.
    */
   options: DefineStoreOptionsInPlugin<Id, S, G, A>
 }

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -122,7 +122,7 @@ export interface PiniaPluginContext<
   store: Store<Id, S, G, A>
 
   /**
-   * Options object defining the store passed to `defineStore()`.
+   * Initial options defining the store when calling `defineStore()`.
    */
   options: DefineStoreOptionsInPlugin<Id, S, G, A>
 }


### PR DESCRIPTION
`options` is an object defining the store passed to `defineStore()`, per https://pinia.vuejs.org/core-concepts/plugins.html#introduction