### PR TITLE
Change Vue School banner affiliate key

### DIFF
--- a/packages/docs/.vitepress/components/Banner.vue
+++ b/packages/docs/.vitepress/components/Banner.vue
@@ -2,7 +2,7 @@
   <a
     id="vs"
     v-if="isVisible"
-    href="https://vueschool.io/free-weekend?friend=pinia"
+    href="https://vueschool.io/free-weekend?friend=vuerouter"
     target="_blank"
     rel="noreferrer"
   >


### PR DESCRIPTION
This PR changes the affiliate link of the Vue School banner, to use the key `vuerouter` instead of `pinia`.