### PR TITLE
docs: missing comma

### DIFF
--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -99,7 +99,7 @@ export default {
     // other computed properties
     // ...
     // gives access to this.counterStore and this.userStore
-    ...mapStores(useCounterStore, useUserStore)
+    ...mapStores(useCounterStore, useUserStore),
     // gives read access to this.count and this.double
     ...mapState(useCounterStore, ['count', 'double']),
   },


### PR DESCRIPTION
In the example of the official document, there is a `missing comma`, resulting in a syntax error when copying and running