### PR TITLE
feat: allow $onAction callbacks to change behavior

### DIFF
--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -202,6 +202,10 @@ const unsubscribe = someStore.$onAction(
           Date.now() - startTime
         }ms.\nResult: ${result}.`
       )
+
+      // returning a value will override action's return value.
+      // this should be done only once.
+      return result * 2
     })
 
     // this will trigger if the action throws or returns a promise that rejects
@@ -209,6 +213,9 @@ const unsubscribe = someStore.$onAction(
       console.warn(
         `Failed "${name}" after ${Date.now() - startTime}ms.\nError: ${error}.`
       )
+
+      // returning false will stop error from propagating.
+      return false;
     })
   }
 )

--- a/packages/pinia/src/subscriptions.ts
+++ b/packages/pinia/src/subscriptions.ts
@@ -29,8 +29,12 @@ export function addSubscription<T extends _Method>(
 export function triggerSubscriptions<T extends _Method>(
   subscriptions: T[],
   ...args: Parameters<T>
-) {
-  subscriptions.slice().forEach((callback) => {
-    callback(...args)
-  })
+) : any[] {
+    const allResults: Array<any> = []
+
+    subscriptions.slice().forEach((callback) => {
+      allResults.push(callback(...args))
+    })
+
+    return allResults
 }


### PR DESCRIPTION
## Description
Currently action.onError() is not very usable. If user wants to handle the error globally using onError(), error has to propagate out of action. This will trigger onError() but there is no way to prevent error to propagate further on and user has a unhandled error warning. If error is to be handled within action, onError() doesn't get triggered.

Researching a solution I noticed a 2 lines in API docs.
> after(callback): void 
> ...Can return a value (other than undefined) to override the returned value.

> onError(callback): void 
> ...Return false to catch the error and stop it from propagating.

## Implementation
- action.onError(): Can stop error propagation if callback returns false.
- action.after() : Can override action's return value.
- - Only one of the callbacks is allowed to do override. More than one will cause a console warning.
- - Last result in array of results will be used for override.
