### PR TITLE
Fixed missing comma in return statement

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -86,7 +86,7 @@ export default defineComponent({
 
     return {
       name,
-      doubleCount
+      doubleCount,
       increment,
     }
   },


### PR DESCRIPTION
Return statement was missing a comma. Copy and pasting this code would result in an error. 