### PR TITLE
Docs - Fixed getter name in vuex example

### DIFF
--- a/packages/docs/cookbook/migration-vuex.md
+++ b/packages/docs/cookbook/migration-vuex.md
@@ -208,7 +208,7 @@ export default defineComponent({
     const store = useStore()
 
     const firstName = computed(() => store.state.auth.user.firstName)
-    const fullName = computed(() => store.getters['auth/user/firstName'])
+    const fullName = computed(() => store.getters['auth/user/fullName'])
 
     return {
       firstName,


### PR DESCRIPTION
Docs(en) Corrected the getter name for full name in example of usage vuex inside the components

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
