### PR TITLE
docs: nuxt mention

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -10,7 +10,7 @@ npm i @pinia/nuxt
 
 ## Usage
 
-Add to `buildModules` in `nuxt.config.js`:
+Add to `modules` (Nuxt 3) or `buildModules` (Nuxt 2) in `nuxt.config.js`:
 
 ```js
 // Nuxt 2

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -13,9 +13,14 @@ npm i @pinia/nuxt
 Add to `buildModules` in `nuxt.config.js`:
 
 ```js
+// Nuxt 2
 export default {
   buildModules: [['@pinia/nuxt', { disableVuex: true }]],
 }
+// Nuxt 3
+export default defineNuxtConfig({
+    modules: ['@pinia/nuxt'],
+})
 ```
 
 Note you also need `@nuxtjs/composition-api` if you are using Nuxt 2 without Bridge. [Refer to docs for more](https://pinia.vuejs.org/ssr/nuxt.html).


### PR DESCRIPTION
Official Nuxt3 docs state that the `buildModules` array is @deprecated — This is no longer needed in Nuxt 3 and Nuxt Bridge; all modules should be added to modules instead.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
