### PR TITLE
Update link to Vue 2 documentation

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -24,7 +24,7 @@ const useStore = defineStore('storeId', {
 ```
 
 :::tip
-If you are using Vue 2, the data you create in `state` follows the same rules as the `data` in a Vue instance, ie the state object must be plain and you need to call `Vue.set()` when **adding new** properties to it. **See also: [Vue#data](https://vuejs.org/v2/api/#data)**.
+If you are using Vue 2, the data you create in `state` follows the same rules as the `data` in a Vue instance, ie the state object must be plain and you need to call `Vue.set()` when **adding new** properties to it. **See also: [Vue#data](https://v2.vuejs.org/v2/api/#data)**.
 :::
 
 ## Accessing the `state`


### PR DESCRIPTION
Use the correct subdomain to link to the Vue 2 documentation. Since the switch to Vue 3 as the default Vue version, to access the Vue 2 documentation the `https://v2.vuejs.org` subdomain must be used.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
