### PR TITLE
feat: allow to $patch writeable computed refs in setup stores

### DIFF
--- a/packages/pinia/__tests__/storeSetup.spec.ts
+++ b/packages/pinia/__tests__/storeSetup.spec.ts
@@ -131,4 +131,34 @@ describe('store with setup syntax', () => {
     expect(store.counter).toBe(2)
     expect(counter.value).toBe(2)
   })
+
+  it('handles writeable computed refs', () => {
+    const counter = ref(1)
+    const double = computed({
+      get: () => counter.value * 2,
+      set(val) {
+        counter.value = val / 2
+      },
+    })
+    const useStore = defineStore('main', () => ({
+      counter,
+      double,
+    }))
+    const store = useStore()
+    expect(store.$state.counter).toBe(1)
+    expect(store.$state.double).toBe(2)
+
+    store.$patch({ counter: 2 })
+    expect(store.$state.double).toBe(4)
+    expect(store.double).toBe(4)
+    expect(double.value).toBe(4)
+
+    store.$patch({ double: 8 })
+    expect(store.$state.counter).toBe(4)
+    expect(store.counter).toBe(4)
+    expect(counter.value).toBe(4)
+    expect(store.$state.double).toBe(8)
+    expect(store.double).toBe(8)
+    expect(double.value).toBe(8)
+  })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -10,6 +10,7 @@ import {
   markRaw,
   isRef,
   isReactive,
+  isReadonly,
   effectScope,
   EffectScope,
   ComputedRef,
@@ -105,11 +106,6 @@ function shouldHydrate(obj: any) {
 }
 
 const { assign } = Object
-
-function isComputed<T>(value: ComputedRef<T> | unknown): value is ComputedRef<T>
-function isComputed(o: any): o is ComputedRef {
-  return !!(isRef(o) && (o as any).effect)
-}
 
 function createOptionsStore<
   Id extends string,
@@ -460,7 +456,7 @@ function createSetupStore<
   for (const key in setupStore) {
     const prop = setupStore[key]
 
-    if ((isRef(prop) && !isComputed(prop)) || isReactive(prop)) {
+    if ((isRef(prop) || isReactive(prop)) && !isReadonly(prop)) {
       // mark it as a piece of state to be serialized
       if (__DEV__ && hot) {
         set(hotState.value, key, toRef(setupStore as any, key))
@@ -513,7 +509,7 @@ function createSetupStore<
       optionsForPlugin.actions[key] = prop
     } else if (__DEV__) {
       // add getters for devtools
-      if (isComputed(prop)) {
+      if (isReadonly(prop)) {
         _hmrPayload.getters[key] = isOptionsStore
           ? // @ts-expect-error
             options.getters[key]

--- a/packages/playground/src/stores/counterSetup.ts
+++ b/packages/playground/src/stores/counterSetup.ts
@@ -11,7 +11,12 @@ export const useCounter = defineStore('counter-setup', () => {
     numbers: [] as number[],
   })
 
-  const double = computed(() => state.n * 2)
+  const double = computed({
+    get: () => state.n * 2,
+    set: (v) => {
+      state.n = v / 2
+    },
+  })
 
   function increment(amount = 1) {
     if (typeof amount !== 'number') {

--- a/packages/playground/src/views/CounterSetupStore.vue
+++ b/packages/playground/src/views/CounterSetupStore.vue
@@ -24,6 +24,16 @@
     >
       Direct patch
     </button>
+    <button
+      @click="
+        counter.$patch((state) => {
+          state.double += 2
+          state.incrementedTimes++
+        })
+      "
+    >
+      Patch double
+    </button>
   </p>
 
   <p>


### PR DESCRIPTION
currently its not possible to $patch writeable computed refs in setup stores

example:
```ts
const counter = ref(0)
const double = computed({
  get: () => counter.value,
  set: (d) => ( counter.value = d/2 )
})

const useStore = defineStore('main', () => ({
  counter,
  double,
}))

const store = useStore()

// double is missing in store.$state
// store.$state == {counter: 0}

// works, but store.$state.double still isn't there
store.double = 4
// doesn't update the store
store.$patch({double: 8})
// now store.$state.double is 8, but store.double is still 4
```


[repro](https://sfc.vuejs.org/#__DEV__eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8bGFiZWw+Y291bnRlciA8aW5wdXQgdHlwZT1cIm51bWJlclwiIHYtbW9kZWwubnVtYmVyPVwic3RvcmUuY291bnRlclwiIC8+PC9sYWJlbD5cbiAgPGxhYmVsPmRvdWJsZSA8aW5wdXQgdHlwZT1cIm51bWJlclwiIHYtbW9kZWwubnVtYmVyPVwic3RvcmUuZG91YmxlXCIgLz48L2xhYmVsPlxuICA8aDE+e3sge2NvdW50ZXIsIGRvdWJsZX0gfX08L2gxPlxuICA8YnV0dG9uIEBjbGljaz1cInN0b3JlLiRwYXRjaCh7ZG91YmxlOiAxNn0pXCI+XG4gICAgc3RvcmUuJHBhdGNoKHtkb3VibGU6IDE2fSlcbiAgPC9idXR0b24+XG4gIDxwPnN0b3JlOjwvcD5cbiAgPHByZT57e3N0b3JlfX08L3ByZT5cbiAgc3RvcmUuJHN0YXRlOlxuICA8cHJlPnt7c3RvcmUuJHN0YXRlfX08L3ByZT5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXA+XG5pbXBvcnQgeyByZWYsIGNvbXB1dGVkLCByZWFkb25seSwgZ2V0Q3VycmVudEluc3RhbmNlIH0gZnJvbSAndnVlLWRlbWknXG5pbXBvcnQgeyBkZWZpbmVTdG9yZSwgY3JlYXRlUGluaWEgfSBmcm9tICdwaW5pYSdcblxuZ2V0Q3VycmVudEluc3RhbmNlKCkuYXBwQ29udGV4dC5hcHAudXNlKGNyZWF0ZVBpbmlhKCkpXG5cbmNvbnN0IGNvdW50ZXIgPSByZWYoMClcbmNvbnN0IGRvdWJsZSA9IGNvbXB1dGVkKHtcbiAgZ2V0OiAoKSA9PiBjb3VudGVyLnZhbHVlICogMixcbiAgc2V0OiAoZCkgPT4ge1xuICAgIGNvdW50ZXIudmFsdWUgPSBkLzJcbiAgfVxufSlcblxuY29uc3QgdXNlU3RvcmUgPSBkZWZpbmVTdG9yZSgnbWFpbicsICgpID0+ICh7XG4gIGNvdW50ZXIsXG4gIGRvdWJsZSxcbn0pKVxuXG5jb25zdCBzdG9yZSA9IHVzZVN0b3JlKClcblxuLy8gZG91YmxlIGlzIG1pc3NpbmcgaW4gc3RvcmUuJHN0YXRlXG4vLyBzdG9yZS4kc3RhdGUgPT0ge2NvdW50ZXI6IDB9XG5cbi8vIHdvcmtzLCBidXQgc3RvcmUuJHN0YXRlLmRvdWJsZSBzdGlsbCBpc24ndCB0aGVyZVxuc3RvcmUuZG91YmxlID0gNFxuLy8gZG9lc24ndCB1cGRhdGUgdGhlIHN0b3JlXG5zdG9yZS4kcGF0Y2goe2RvdWJsZTogOH0pXG4vLyBub3cgc3RvcmUuJHN0YXRlLmRvdWJsZSBpcyA4LCBidXQgc3RvcmUuZG91YmxlIGlzIHN0aWxsIDRcbjwvc2NyaXB0PiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL3Z1ZUAzLjIuMzYvZGlzdC92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwicGluaWFcIjogXCJodHRwczovL3VucGtnLmNvbS9waW5pYUAyLjAuMTQvZGlzdC9waW5pYS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwidnVlLWRlbWlcIjogXCJodHRwczovL3VucGtnLmNvbS92dWUtZGVtaS9saWIvaW5kZXgubWpzXCIsXG4gICAgXCJ2dWUvc2VydmVyLXJlbmRlcmVyXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQHZ1ZS9zZXJ2ZXItcmVuZGVyZXIvZGlzdC9zZXJ2ZXItcmVuZGVyZXIuZXNtLWJyb3dzZXIuanNcIixcbiAgICBcIkB2dWUvZGV2dG9vbHMtYXBpXCI6IFwiaHR0cHM6Ly91bnBrZy5jb20vQHZ1ZS9kZXZ0b29scy1hcGk/bW9kdWxlXCJcbiAgfVxufSJ9) 

so this pr changes the `isComputed` checks to the `isReadonly` function from vue,
since computed refs with only a getter are readonly and with a setter they aren't