### PR TITLE
small update to follow conventions

### DIFF
--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -123,7 +123,7 @@ Here is a more complete example of the API you will be using with Pinia **with t
 ```js
 import { defineStore } from 'pinia'
 
-export const todos = defineStore('todos', {
+export const useTodos = defineStore('todos', {
   state: () => ({
     /** @type {{ text: string, id: number, isFinished: boolean }[]} */
     todos: [],


### PR DESCRIPTION
On https://pinia.vuejs.org/core-concepts/ it is mentioned that "Naming the returned function use... is a convention across composables to make its usage idiomatic.". In this example though, the returned function is called `todos` as opposed to `useTodos`.
