### PR TITLE
docs: create a pinia example (#1374) [skip ci]

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -14,19 +14,18 @@ If your app is using Vue 2, you also need to install the composition api: `@vue/
 
 If you are using the Vue CLI, you can instead give this [**unofficial plugin**](https://github.com/wobsoriano/vue-cli-plugin-pinia) a try.
 
-Create a pinia (the root store) and pass it to the app(in `main.js`):
+Create a pinia instance (the root store) and pass it to the app as a plugin:
 
-```js
-import { createApp } from "vue";
-import { createPinia } from "pinia";
+```js{2,5-6,8}
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
 
-import App from "./App.vue";
+const pinia = createPinia()
+const app = createApp(App)
 
-const pinia = createPinia();
-const app = createApp(App);
-
-app.use(pinia);
-app.mount("#app");
+app.use(pinia)
+app.mount('#app')
 ```
 
 If you are using Vue 2, you also need to install a plugin and inject the created `pinia` at the root of the app:

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -14,12 +14,19 @@ If your app is using Vue 2, you also need to install the composition api: `@vue/
 
 If you are using the Vue CLI, you can instead give this [**unofficial plugin**](https://github.com/wobsoriano/vue-cli-plugin-pinia) a try.
 
-Create a pinia (the root store) and pass it to the app:
+Create a pinia (the root store) and pass it to the app(in `main.js`):
 
 ```js
-import { createPinia } from 'pinia'
+import { createApp } from "vue";
+import { createPinia } from "pinia";
 
-app.use(createPinia())
+import App from "./App.vue";
+
+const pinia = createPinia();
+const app = createApp(App);
+
+app.use(pinia);
+app.mount("#app");
 ```
 
 If you are using Vue 2, you also need to install a plugin and inject the created `pinia` at the root of the app:


### PR DESCRIPTION
The current example caused a bit of confusion for me:

```js
import { createPinia } from 'pinia'

app.use(createPinia())
```

After some trial and error and reading the errors in devtools I realized that what I needed was the following in `main.js`(Note I am using Vue3 with Vite)

```js
import { createApp } from "vue";
import { createPinia } from "pinia";

import App from "./App.vue";

const pinia = createPinia();
const app = createApp(App);

app.use(pinia);
app.mount("#app");
```
