### PR TITLE
docs: fix line highlights

### DIFF
--- a/packages/docs/.vitepress/theme/code-theme.css
+++ b/packages/docs/.vitepress/theme/code-theme.css
@@ -303,6 +303,11 @@ html.light .token.italic {
   font-style: italic;
 }
 
+/* Fix https://github.com/vuejs/vitepress/issues/63 */
+.highlight-lines {
+  padding: 20px 0 0 0;
+}
+
 .highlight-lines .highlighted {
   background-color: var(--code-highlight-bg-color);
 }

--- a/packages/docs/.vitepress/theme/code-theme.css
+++ b/packages/docs/.vitepress/theme/code-theme.css
@@ -302,3 +302,7 @@ html.light .token.bold {
 html.light .token.italic {
   font-style: italic;
 }
+
+.highlight-lines .highlighted {
+  background-color: var(--code-highlight-bg-color);
+}

--- a/packages/docs/.vitepress/theme/custom.css
+++ b/packages/docs/.vitepress/theme/custom.css
@@ -80,6 +80,7 @@
   --code-font-family: 'dm', source-code-pro, Menlo, Monaco, Consolas,
     'Courier New', monospace;
   --code-font-size: 16px;
+  --code-line-height: 1.7;
 }
 
 .custom-block.tip {

--- a/packages/docs/.vitepress/theme/custom.css
+++ b/packages/docs/.vitepress/theme/custom.css
@@ -61,6 +61,7 @@
   --c-yellow: #ffd859;
   --c-yellow-light: #f7d336;
   --c-white-dark: #f8f8f8;
+  --c-white-darker: #e8ede6;
   --c-black: #111827;
   --c-black-light: #161f32;
   --c-black-lighter: #262a44;
@@ -74,6 +75,7 @@
   --c-brand-text: var(--c-text-light-1);
   --c-bg-accent: var(--c-white-dark);
   --code-bg-color: var(--c-white-dark);
+  --code-highlight-bg-color: var(--c-white-darker);
   --code-inline-bg-color: var(--c-white-dark);
   --code-font-family: 'dm', source-code-pro, Menlo, Monaco, Consolas,
     'Courier New', monospace;
@@ -119,6 +121,7 @@ html:not(.light):root {
   --c-bg: var(--c-black);
   --c-bg-accent: var(--c-black-light);
   --code-bg-color: var(--c-black-light);
+  --code-highlight-bg-color: var(--c-black-lighter);
   --code-inline-bg-color: var(--c-black-light);
 }
 

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -16,7 +16,7 @@ If you are using the Vue CLI, you can instead give this [**unofficial plugin**](
 
 Create a pinia instance (the root store) and pass it to the app as a plugin:
 
-```js{2,5-6,8}
+```js %{2,5-6,8}%
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
@@ -30,7 +30,7 @@ app.mount('#app')
 
 If you are using Vue 2, you also need to install a plugin and inject the created `pinia` at the root of the app:
 
-```js{1,3-4,12}
+```js %{1,3-4,12}%
 import { createPinia, PiniaVuePlugin } from 'pinia'
 
 Vue.use(PiniaVuePlugin)

--- a/packages/docs/introduction.md
+++ b/packages/docs/introduction.md
@@ -77,7 +77,7 @@ export const useCounterStore = defineStore('counter', () => {
 
 If you are still not into `setup()` and Composition API, don't worry, Pinia also support a similar set of [_map helpers_ like Vuex](https://vuex.vuejs.org/guide/state.html#the-mapstate-helper). You define stores the same way but then use `mapStores()`, `mapState()`, or `mapActions()`:
 
-```js{22,24,28}
+```js %{22,24,28}%
 const useCounterStore = defineStore('counter', {
   state: () => ({ count: 0 }),
   getters: {


### PR DESCRIPTION
Per [1](https://github.com/vuejs/pinia/blob/667b81dfd7888bbae562bbd02c3670d4c664a8e2/packages/docs/.vitepress/config.js#L31) and [2](https://github.com/vuejs/vitepress/blob/75ca9e4302c65e3bcc9518f7df928318380f6cf6/src/node/markdown/plugins/highlightLines.ts#L13), replace `{` & `}` with `%{` and `}%` because we customized attrs

Before:
Complain that the language does not exist
<img width="263" alt="Screen Shot 2022-06-20 at 12 31 22 AM" src="https://user-images.githubusercontent.com/10359255/174548500-a0658a7a-6535-41bf-a5ce-5e3ca56e63d8.png">
Code is not correctly highlighted:
<img width="413" alt="Screen Shot 2022-06-20 at 12 32 42 AM" src="https://user-images.githubusercontent.com/10359255/174548761-baa9c418-25b9-4758-83b4-2162883dcb9f.png">

After:
<img width="806" alt="Screen Shot 2022-06-20 at 1 00 14 AM" src="https://user-images.githubusercontent.com/10359255/174553992-d697cc5a-de1c-4f8e-b50d-bcf03dc39e45.png">
<img width="808" alt="Screen Shot 2022-06-20 at 1 02 28 AM" src="https://user-images.githubusercontent.com/10359255/174554141-804ecc10-13da-4f23-9770-2e6e0f506bbd.png">

