### PR TITLE
fix: install devtools plugin only after app is created and installed (#1063)

### DIFF
--- a/packages/pinia/src/createPinia.ts
+++ b/packages/pinia/src/createPinia.ts
@@ -18,6 +18,8 @@ export function createPinia(): Pinia {
   let _p: Pinia['_p'] = []
   // plugins added before calling app.use(pinia)
   let toBeInstalled: PiniaPlugin[] = []
+  let afterInitializeCallbacks: ((app: App) => void)[] = []
+  let _a: App | null = null
 
   const pinia: Pinia = markRaw({
     install(app: App) {
@@ -47,9 +49,27 @@ export function createPinia(): Pinia {
     },
 
     _p,
-    // it's actually undefined here
-    // @ts-expect-error
-    _a: null,
+
+    get _a() {
+      return _a!
+    },
+    set _a(app) {
+      _a = app
+
+      if (app) {
+        afterInitializeCallbacks.forEach((cb) => cb(app))
+        afterInitializeCallbacks = []
+      }
+    },
+
+    afterAppInit(cb: (app: App) => void) {
+      if (_a) {
+        cb(_a)
+      } else {
+        afterInitializeCallbacks.push(cb)
+      }
+    },
+
     _e: scope,
     _s: new Map<string, StoreGeneric>(),
     state,

--- a/packages/pinia/src/createPinia.ts
+++ b/packages/pinia/src/createPinia.ts
@@ -18,7 +18,7 @@ export function createPinia(): Pinia {
   let _p: Pinia['_p'] = []
   // plugins added before calling app.use(pinia)
   let toBeInstalled: PiniaPlugin[] = []
-  let afterInitializeCallbacks: ((app: App) => void)[] = []
+  let onInstallCallbacks: ((app: App) => void)[] = []
   let _a: App | null = null
 
   const pinia: Pinia = markRaw({
@@ -57,16 +57,16 @@ export function createPinia(): Pinia {
       _a = app
 
       if (app) {
-        afterInitializeCallbacks.forEach((cb) => cb(app))
-        afterInitializeCallbacks = []
+        onInstallCallbacks.forEach((cb) => cb(app))
+        onInstallCallbacks = []
       }
     },
 
-    afterAppInit(cb: (app: App) => void) {
+    onInstall(cb: (app: App) => void) {
       if (_a) {
         cb(_a)
       } else {
-        afterInitializeCallbacks.push(cb)
+        onInstallCallbacks.push(cb)
       }
     },
 

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -521,7 +521,7 @@ export function devtoolsPlugin<
   S extends StateTree = StateTree,
   G /* extends GettersTree<S> */ = _GettersTree<S>,
   A /* extends ActionsTree */ = _ActionsTree
->({ app, store, options }: PiniaPluginContext<Id, S, G, A>) {
+>({ store, options, pinia }: PiniaPluginContext<Id, S, G, A>) {
   // HMR module
   if (store.$id.startsWith('__hot:')) {
     return
@@ -553,9 +553,11 @@ export function devtoolsPlugin<
     }
   }
 
-  addStoreToDevtools(
-    app,
-    // FIXME: is there a way to allow the assignment from Store<Id, S, G, A> to StoreGeneric?
-    store as StoreGeneric
+  pinia.onInstall((app) =>
+    addStoreToDevtools(
+      app,
+      // FIXME: is there a way to allow the assignment from Store<Id, S, G, A> to StoreGeneric?
+      store as StoreGeneric
+    )
   )
 }

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -58,12 +58,12 @@ export interface Pinia {
   use(plugin: PiniaPlugin): Pinia
 
   /**
-   * Executes callback after pinia._a is set, or immediately, if it is set already
+   * Executes callback after Pinia is installed into Vue app
    *
    * @internal
    * @param cb - callback to execute
    */
-  afterAppInit(cb: (app: App) => void): void
+  onInstall(cb: (app: App) => void): void
 
   /**
    * Installed store plugins

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -58,6 +58,14 @@ export interface Pinia {
   use(plugin: PiniaPlugin): Pinia
 
   /**
+   * Executes callback after pinia._a is set, or immediately, if it is set already
+   *
+   * @internal
+   * @param cb - callback to execute
+   */
+  afterAppInit(cb: (app: App) => void): void
+
+  /**
    * Installed store plugins
    *
    * @internal

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -676,36 +676,34 @@ function createSetupStore<
   }
 
   // apply all plugins
-  pinia.afterAppInit((app) => {
-    pinia._p.forEach((extender) => {
-      /* istanbul ignore else */
-      if (__DEV__ && IS_CLIENT) {
-        const extensions = scope.run(() =>
+  pinia._p.forEach((extender) => {
+    /* istanbul ignore else */
+    if (__DEV__ && IS_CLIENT) {
+      const extensions = scope.run(() =>
+        extender({
+          store,
+          app: pinia._a,
+          pinia,
+          options: optionsForPlugin,
+        })
+      )!
+      Object.keys(extensions || {}).forEach((key) =>
+        store._customProperties.add(key)
+      )
+      assign(store, extensions)
+    } else {
+      assign(
+        store,
+        scope.run(() =>
           extender({
             store,
-            app,
+            app: pinia._a,
             pinia,
             options: optionsForPlugin,
           })
         )!
-        Object.keys(extensions || {}).forEach((key) =>
-          store._customProperties.add(key)
-        )
-        assign(store, extensions)
-      } else {
-        assign(
-          store,
-          scope.run(() =>
-            extender({
-              store,
-              app,
-              pinia,
-              options: optionsForPlugin,
-            })
-          )!
-        )
-      }
-    })
+      )
+    }
   })
 
   if (

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -676,34 +676,36 @@ function createSetupStore<
   }
 
   // apply all plugins
-  pinia._p.forEach((extender) => {
-    /* istanbul ignore else */
-    if (__DEV__ && IS_CLIENT) {
-      const extensions = scope.run(() =>
-        extender({
-          store,
-          app: pinia._a,
-          pinia,
-          options: optionsForPlugin,
-        })
-      )!
-      Object.keys(extensions || {}).forEach((key) =>
-        store._customProperties.add(key)
-      )
-      assign(store, extensions)
-    } else {
-      assign(
-        store,
-        scope.run(() =>
+  pinia.afterAppInit((app) => {
+    pinia._p.forEach((extender) => {
+      /* istanbul ignore else */
+      if (__DEV__ && IS_CLIENT) {
+        const extensions = scope.run(() =>
           extender({
             store,
-            app: pinia._a,
+            app,
             pinia,
             options: optionsForPlugin,
           })
         )!
-      )
-    }
+        Object.keys(extensions || {}).forEach((key) =>
+          store._customProperties.add(key)
+        )
+        assign(store, extensions)
+      } else {
+        assign(
+          store,
+          scope.run(() =>
+            extender({
+              store,
+              app,
+              pinia,
+              options: optionsForPlugin,
+            })
+          )!
+        )
+      }
+    })
   })
 
   if (


### PR DESCRIPTION
Closes https://github.com/vuejs/pinia/issues/1063

Turned out in nuxt plugin environment, `pinia._a` is not yet defined which resulted in devtools unable to find app record.