### PR TITLE
fix(nuxt): plugin injection on latest Nuxt 3 context

### DIFF
--- a/packages/nuxt/src/templates/plugin.ts
+++ b/packages/nuxt/src/templates/plugin.ts
@@ -49,10 +49,10 @@ const PiniaNuxtPlugin: Plugin = (context, inject) => {
     } else {
       // there is no beforeNuxtRender in Nuxt 3
       // @ts-expect-error: vue 3 only
-      context.ssrContext.payload.data.pinia = pinia.state.value
+      context.ssrContext.payload.pinia = pinia.state.value
     }
   } else {
-    const source = isVue2 ? context.nuxtState : context.payload.data
+    const source = isVue2 ? context.nuxtState : context.payload
     if (source && source.pinia) {
       pinia.state.value = source.pinia
     }

--- a/packages/nuxt/src/templates/plugin.ts
+++ b/packages/nuxt/src/templates/plugin.ts
@@ -22,7 +22,12 @@ const PiniaNuxtPlugin: Plugin = (context, inject) => {
   // make sure to inject pinia after installing the plugin because in Nuxt 3, inject defines a non configurable getter
   // on app.config.globalProperties
   // add $pinia to the context
-  inject('pinia', pinia)
+  if (isVue2) {
+    inject('pinia', pinia)
+  } else {
+    // @ts-expect-error: vue 3 only
+    context.provide('pinia', pinia)
+  }
   // to allow accessing pinia without the $
   // TODO: remove this in deprecation
   context.pinia = pinia
@@ -43,10 +48,14 @@ const PiniaNuxtPlugin: Plugin = (context, inject) => {
       })
     } else {
       // there is no beforeNuxtRender in Nuxt 3
-      context.nuxtState.pinia = pinia.state.value
+      // @ts-expect-error: vue 3 only
+      context.ssrContext.payload.data.pinia = pinia.state.value
     }
-  } else if (context.nuxtState && context.nuxtState.pinia) {
-    pinia.state.value = context.nuxtState.pinia
+  } else {
+    const source = isVue2 ? context.nuxtState : context.payload.data
+    if (source && source.pinia) {
+      pinia.state.value = source.pinia
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

As Nuxt 3 removed the legacy context (https://github.com/nuxt/framework/pull/5630), the `inject` argument and `nuxtState` option is not available anymore.

Fixes #1428
fix #1432 