### PR TITLE
fix: types when esm exports

### DIFF
--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -22,7 +22,8 @@
           "default": "./index.js"
         }
       },
-      "import": "./dist/pinia.mjs"
+      "import": "./dist/pinia.mjs",
+      "types": "./dist/pinia.d.ts"
     },
     "./package.json": "./package.json",
     "./dist/*": "./dist/*"


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

When using `"moduleResolution": "node16"` in tsconfig, the pinia doesn't get type definition.
It will get the `TS7016: Could not find a declaration file for module `pinia`` error.
![截圖 2022-07-12 下午12 38 15](https://user-images.githubusercontent.com/9126398/178409658-7b3c3f57-bd63-4ac7-a058-fac6f691d24b.png)

I add the `types` field in `exports` with `package.json`. It works well.
![截圖 2022-07-12 下午12 41 45](https://user-images.githubusercontent.com/9126398/178410068-664a5715-867c-4e0a-a530-9c1767eda9f3.png)

