### PR TITLE
docs: clarify composing-stores.md, remove duplicate example (#1467) [skip ci]

### DIFF
--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -42,7 +42,7 @@ const useY = defineStore('y', () => {
 
 ## Using a store within another store
 
-Note that if one store uses another store, you can directly import and call the `use${storeName}Store` method, and access methods on the store object, just like you would access them from within a Vue component.
+Note that if one store uses another store, you can directly import and call the `use${storeName}Store` method, then access methods on the returned store object, just like you would access them from within a Vue component.
 
 You can call `useOtherStore()` inside any getter or action:
 

--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -1,6 +1,6 @@
 # Composing Stores
 
-Composing stores is about having stores that use each other and there is one rule to follow:
+Composing stores is about having stores that use each other's state / methods, and this is supported in Pinia. There is one rule to follow:
 
 If **two or more stores use each other**, they cannot create an infinite loop through _getters_ or _actions_. They cannot **both** directly read each other state in their setup function:
 
@@ -40,34 +40,12 @@ const useY = defineStore('y', () => {
 })
 ```
 
-## Nested stores
+## Using a store within another store
 
-Note that if one store uses another store, **there is no need to create a new store in a separate file**, you can directly import it. Think of it as nesting.
+Note that if one store uses another store, you can directly import and call the `use${storeName}Store` method, and access methods on the store object, just like you would access them from within a Vue component.
 
-You can call `useOtherStore()` at the top of any getter or action:
+You can call `useOtherStore()` inside any getter or action:
 
-```js
-import { useUserStore } from './user'
-
-export const cartStore = defineStore('cart', {
-  getters: {
-    // ... other getters
-    summary(state) {
-      const user = useUserStore()
-
-      return `Hi ${user.name}, you have ${state.list.length} items in your cart. It costs ${state.price}.`
-    },
-  },
-
-  actions: {
-    purchase() {
-      const user = useUserStore()
-
-      return apiPurchase(user.id, this.list)
-    },
-  },
-})
-```
 
 ## Shared Getters
 

--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -1,6 +1,6 @@
 # Composing Stores
 
-Composing stores is about having stores that use each other's state / methods, and this is supported in Pinia. There is one rule to follow:
+Composing stores is about having stores that use each other, and this is supported in Pinia. There is one rule to follow:
 
 If **two or more stores use each other**, they cannot create an infinite loop through _getters_ or _actions_. They cannot **both** directly read each other state in their setup function:
 
@@ -40,12 +40,9 @@ const useY = defineStore('y', () => {
 })
 ```
 
-## Using a store within another store
+## Nested Stores
 
-Note that if one store uses another store, you can directly import and call the `use${storeName}Store` method, then access methods on the returned store object, just like you would access them from within a Vue component.
-
-You can call `useOtherStore()` inside any getter or action:
-
+Note that if one store uses another store, you can directly import and call the `useStore()` function within _actions_ and _getters_. Then you can interact with the store just like you would from within a Vue component. See [Shared Getters](#shared-getters) and [Shared Actions](#shared-actions).
 
 ## Shared Getters
 


### PR DESCRIPTION
We had a code example with a getter and an action, then one with the getter, then one with the action.
I removed the first one.

I also clarified right up at the front that sharing state/methods between stores is supported in Pinia, since I believe a lot of people will find this doc by searching that exact question.

I also removed a mention of 'nesting' because we use that specific term elsewhere to refer to a file/folder structure, and it doesn't seem to me to be semantically useful - it's just a store using a store, I don't think there's any hierarchy implied.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
