### PR TITLE
docs: The description of $state does not match the pinia source code implementation

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -147,9 +147,9 @@ cartStore.$patch((state) => {
 
 The main difference here is that `$patch()` allows you to group multiple changes into one single entry in the devtools. Note **both, direct changes to `state` and `$patch()` appear in the devtools** and can be time traveled (not yet in Vue 3).
 
-## Replacing the `state`
+## Merging the `state`
 
-You can replace the whole state of a store by setting its `$state` property to a new object:
+You can merge a new object into a state of store by setting its `$state` property:
 
 ```js
 store.$state = { counter: 24 }


### PR DESCRIPTION
The implementation of $state in the source code is not to replace the whole state of a store, but to merge it.
It does not match the results in practical applications. It is more appropriate to modify it to merge the incoming objects here.
![image](https://user-images.githubusercontent.com/10335230/180607584-663cc089-56c9-4565-90a7-4cb5a469cb70.png)
