### PR TITLE
docs: minor update of index.md to explain defineStore arguments (#1475) [skip ci]

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -10,7 +10,7 @@ Before diving into core concepts, we need to know that a store is defined using 
 ```js
 import { defineStore } from 'pinia'
 
-// useStore could be anything like useUser, useCart
+// useStore is an arbitrary name but a good convention- it could be anything like useUserStore, useCartStore
 // the first argument is a unique id of the store across your application
 export const useStore = defineStore('main', {
   // other options...
@@ -19,7 +19,43 @@ export const useStore = defineStore('main', {
 
 This _name_, also referred as _id_, is necessary and is used by Pinia to connect the store to the devtools. Naming the returned function _use..._ is a convention across composables to make its usage idiomatic.
 
-## Using the store
+`defineStore()` accepts two distinct values for its second argument: a Setup function or an Options object.
+
+## Defining a store using Setup Function
+
+Similar to the Vue Composition API's [setup function](https://vuejs.org/api/composition-api-setup.html), we can pass in a `storeSetup` function that defines reactive properties and methods. 
+
+```js
+
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0)
+  function increment() {
+    count.value++
+  }
+
+  return { count, increment }
+})
+```
+
+## Defining a Store using an Options object
+
+Similar to Vue's Options API, we can also pass an Options Object with `state`, `actions`, and `getters` properties. 
+
+```js {22,24,28}
+export const useCounterStore = defineStore('counter', {
+  state: () => ({ count: 0 }),
+  getters: {
+    double: (state) => state.count * 2,
+  },
+  actions: {
+    increment() {
+      this.count++
+    },
+  },
+})
+```
+
+# Using the store
 
 We are _defining_ a store because the store won't be created until `useStore()` is called inside of `setup()`:
 

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -10,7 +10,7 @@ Before diving into core concepts, we need to know that a store is defined using 
 ```js
 import { defineStore } from 'pinia'
 
-// useStore is an arbitrary name but a good convention- it could be anything like useUserStore, useCartStore
+// You can name the return value of `defineStore()` anything you want, but it's best to use the name of the store and surround it with `use` and `Store` (e.g. `useUserStore`, `useCartStore`, `useProductStore`)
 // the first argument is a unique id of the store across your application
 export const useStore = defineStore('main', {
   // other options...
@@ -21,26 +21,11 @@ This _name_, also referred as _id_, is necessary and is used by Pinia to connect
 
 `defineStore()` accepts two distinct values for its second argument: a Setup function or an Options object.
 
-## Defining a store using Setup Function
+## Option Stores
 
-Similar to the Vue Composition API's [setup function](https://vuejs.org/api/composition-api-setup.html), we can pass in a `storeSetup` function that defines reactive properties and methods. 
+Similar to Vue's Options API, we can also pass an Options Object with `state`, `actions`, and `getters` properties.
 
-```js
-export const useCounterStore = defineStore('counter', () => {
-  const count = ref(0)
-  function increment() {
-    count.value++
-  }
-
-  return { count, increment }
-})
-```
-
-## Defining a Store using an Options object
-
-Similar to Vue's Options API, we can also pass an Options Object with `state`, `actions`, and `getters` properties. 
-
-```js {22,24,28}
+```js {2-10}
 export const useCounterStore = defineStore('counter', {
   state: () => ({ count: 0 }),
   getters: {
@@ -54,7 +39,38 @@ export const useCounterStore = defineStore('counter', {
 })
 ```
 
-# Using the store
+You can think of `state` as the `data` of the store, and `getters` as the `computed` properties of the store, and `actions` as the `methods`.
+
+Options stores should feel intuitive and simple to get started with.
+
+## Setup Stores
+
+There is also another possible syntax to define stores. Similar to the Vue Composition API's [setup function](https://vuejs.org/api/composition-api-setup.html), we can pass in a function that defines reactive properties and methods and returns an object with the properties and methods we want to expose.
+
+```js
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0)
+  function increment() {
+    count.value++
+  }
+
+  return { count, increment }
+})
+```
+
+In _Setup Stores_:
+
+- `ref()`s become `state` properties
+- `computed()`s become `getters`
+- `function()`s become `actions`
+
+Setup stores bring a lot more flexibility than [Options Stores](#option-stores) as you can create watchers within a store and freely use any [composable](https://vuejs.org/guide/reusability/composables.html#composables). However, keep in mind that using composables will complexify [SSR](../ssr/advanced.md).
+
+## What syntax should I pick?
+
+As with [Vue's Composition API and Option API](https://vuejs.org/guide/introduction.html#which-to-choose), pick the one that you feel the most comfortable with. If you're not sure, try the [Option Stores](#option-stores) first.
+
+## Using the store
 
 We are _defining_ a store because the store won't be created until `useStore()` is called inside of `setup()`:
 

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -26,7 +26,6 @@ This _name_, also referred as _id_, is necessary and is used by Pinia to connect
 Similar to the Vue Composition API's [setup function](https://vuejs.org/api/composition-api-setup.html), we can pass in a `storeSetup` function that defines reactive properties and methods. 
 
 ```js
-
 export const useCounterStore = defineStore('counter', () => {
   const count = ref(0)
   function increment() {

--- a/packages/docs/ssr/advanced.md
+++ b/packages/docs/ssr/advanced.md
@@ -1,0 +1,3 @@
+# Advanced SSR
+
+WIP


### PR DESCRIPTION
Subsequent to [this PR discussion](https://github.com/vuejs/pinia/pull/1467#discussion_r928297728) I realised it's not very well documented that defineStore can take a setupStore function as its second argument, I thought it was worth mentioning in the defineStore doc.

Note: "What is Pinia?" also [mentions that you can pass a function](https://pinia.vuejs.org/introduction.html#basic-example:~:text=You%20can%20even%20use%20a%20function%20(similar%20to%20a%20component%20setup())%20to%20define%20a%20Store%20for%20more%20advanced%20use%20cases%3A), but I suspect that a lot of developers won't look there to figure out how defineStore works

[Example of a Reddit comment where a Pinia user had no idea that this was possible](https://www.reddit.com/r/vuejs/comments/snpo86/comment/hw6rh8e/?utm_source=reddit&utm_medium=web2x). Note that the person responding doesn't link to the defineStore doc, but rather an example in an unrelated doc. 