### PR TITLE
docs: Invalid Docs Link

### DIFF
--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -229,7 +229,7 @@ module.exports = {
             },
             {
               text: 'Dealing with composables',
-              link: '/cookbook/composables.html#ssr',
+              link: '/cookbook/composables.html',
             },
           ],
         },

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -229,7 +229,7 @@ module.exports = {
             },
             {
               text: 'Dealing with composables',
-              link: '/cookbook/composables.html',
+              link: '/cookbook/composables.html#ssr',
             },
           ],
         },

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -64,7 +64,7 @@ In _Setup Stores_:
 - `computed()`s become `getters`
 - `function()`s become `actions`
 
-Setup stores bring a lot more flexibility than [Options Stores](#option-stores) as you can create watchers within a store and freely use any [composable](https://vuejs.org/guide/reusability/composables.html#composables). However, keep in mind that using composables will get more complex [SSR](../cookbook//composables.md).
+Setup stores bring a lot more flexibility than [Options Stores](#option-stores) as you can create watchers within a store and freely use any [composable](https://vuejs.org/guide/reusability/composables.html#composables). However, keep in mind that using composables will get more complex [SSR](../cookbook/composables.md).
 
 ## What syntax should I pick?
 


### PR DESCRIPTION
From the `/packages/docs/core-concepts/index.md` documentation:
- `../cookbook//composables.md` → `../cookbook/composables.md`
   This is not a problem on the local server, but there was a 404 problem when hosting it.

Among the sidebar links in the `/packages/docs/.vitepress/config.js` file:
- `/cookbook/composables.html#ssr` → `/cookbook/composables.html`
   This should look at the top of the section.


<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
