### PR TITLE
doc: composition-api is only required for Vue  <= 2.6.x

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -9,7 +9,7 @@ npm install pinia
 ```
 
 :::tip
-If your app is using Vue 2, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).
+If your app is using Vue <= 2.6.x, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).
 :::
 
 If you are using the Vue CLI, you can instead give this [**unofficial plugin**](https://github.com/wobsoriano/vue-cli-plugin-pinia) a try.


### PR DESCRIPTION
With release 2.7 of Vue the composition api is part of Vue. Thus, the composition-api plugin is only required for Vue <= 2.6.x (see https://github.com/vuejs/composition-api).
