### PR TITLE
fix(nuxt): fully resolve pinia path

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -62,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Make sure we use the mjs build for pinia
     nuxt.options.alias.pinia = resolveModule('pinia/dist/pinia.mjs', {
-      paths: [nuxt.options.rootDir, import.meta.url]
+      paths: [nuxt.options.rootDir, import.meta.url],
     })
 
     // Add runtime plugin

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -62,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Make sure we use the mjs build for pinia
     nuxt.options.alias.pinia = resolveModule('pinia/dist/pinia.mjs', {
-      paths: nuxt.options.rootDir,
+      paths: [nuxt.options.rootDir, import.meta.url]
     })
 
     // Add runtime plugin

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -7,6 +7,7 @@ import {
   isNuxt2,
   addAutoImport,
   createResolver,
+  resolveModule,
 } from '@nuxt/kit'
 
 export interface ModuleOptions {
@@ -60,7 +61,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.build.transpile.push(resolver.resolve('./runtime'))
 
     // Make sure we use the mjs build for pinia
-    nuxt.options.alias.pinia = 'pinia/dist/pinia.mjs'
+    nuxt.options.alias.pinia = resolveModule('pinia/dist/pinia.mjs', {
+      paths: nuxt.options.rootDir,
+    })
 
     // Add runtime plugin
     if (isNuxt2()) {


### PR DESCRIPTION
There's a build issue with latest nuxt + pinia: https://stackblitz.com/edit/github-cqsm6q (`npm run build`) with double aliasing (e.g. vite resolves to `pinia/dist/pinia.mjs` then nitro resolves _that_ to `pinia/dist/pinia.mjs/dist/pinia.mjs`.

This fixes the issue but we may also look at changing behaviour upstream in Nuxt/Nitro.

cc: @pi0