### PR TITLE
docs: import in testing

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -84,7 +84,8 @@ And make sure to create a testing pinia in your tests when mounting a component:
 ```js
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
-import { useSomeStore } from '@/stores/some.js' // or wherever else you defined the store
+// import any store you want to interact with in tests
+import { useSomeStore } from '@/stores/myStore'
 
 const wrapper = mount(Counter, {
   global: {

--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -84,6 +84,7 @@ And make sure to create a testing pinia in your tests when mounting a component:
 ```js
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
+import { useSomeStore } from '@/stores/some.js' // or wherever else you defined the store
 
 const wrapper = mount(Counter, {
   global: {


### PR DESCRIPTION
Hi 👋,

This little bit of extra information would have helped me spin up on testing a component that uses Pinia.

I was not sure how `const store = useSomeStore() // uses the testing pinia!` was injected or able to be used.

Hopefully, this bit of code can clarify it for the next person.
```
import { useSomeStore } from '@/stores/some.js' // or wherever else you defined the store
```

It totally makes sense that it needs to be imported in hindsight.  While I was slugging through, I was unsure if `useSomeStore` was injected by `createTestingPinia()` in some magical way.

When everything was new and uncertain, it was hard to dial in on the proper parts to troubleshoot.

Hope that helps 🤞

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
