### PR TITLE
feat(nuxt): automatically add pinia types

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -91,7 +91,7 @@ export default {
 
 ### TypeScript
 
-If you are using TypeScript or have a `jsconfig.json`, you should also add the types for `context.pinia`:
+If you are using Nuxt 2 (`@pinia/nuxt` < 0.3.0) with TypeScript or have a `jsconfig.json`, you should also add the types for `context.pinia`:
 
 ```json
 {

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -14,13 +14,13 @@ We supply a _module_ to handle everything for you, you only need to add it to `b
 
 ```js
 // nuxt.config.js
-export default {
+export default defineNuxtConfig({
   // ... other options
-  buildModules: [
+  modules: [
     // ...
     '@pinia/nuxt',
   ],
-}
+})
 ```
 
 And that's it, use your store as usual!
@@ -64,21 +64,6 @@ export default {
 }
 ```
 
-## TypeScript
-
-If you are using TypeScript or have a `jsconfig.json`, you should also add the types for `context.pinia`:
-
-```json
-{
-  "types": [
-    // ...
-    "@pinia/nuxt"
-  ]
-}
-```
-
-This will also ensure you have autocompletion 😉 .
-
 ## Nuxt 2 without bridge
 
 Pinia supports Nuxt 2 until `@pinia/nuxt` v0.2.1. Make sure to also install [`@nuxtjs/composition-api`](https://composition-api.nuxtjs.org/) alongside `pinia`:
@@ -103,6 +88,21 @@ export default {
   ],
 }
 ```
+
+### TypeScript
+
+If you are using TypeScript or have a `jsconfig.json`, you should also add the types for `context.pinia`:
+
+```json
+{
+  "types": [
+    // ...
+    "@pinia/nuxt"
+  ]
+}
+```
+
+This will also ensure you have autocompletion 😉 .
 
 ### Using Pinia alongside Vuex
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -65,6 +65,10 @@ export default defineNuxtModule<ModuleOptions>({
       paths: [nuxt.options.rootDir, import.meta.url],
     })
 
+    nuxt.hook('prepare:types', ({ references }) => {
+      references.push({ types: '@pinia/nuxt' })
+    })
+
     // Add runtime plugin
     if (isNuxt2()) {
       addPlugin(resolver.resolve('./runtime/plugin.vue2'))


### PR DESCRIPTION
This PR automatically adds the `@pinia/nuxt` types for Nuxt Bridge / Nuxt 3, and moves this section in the docs to the legacy install instructions.