### PR TITLE
docs: fix getter typo

### DIFF
--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -224,7 +224,7 @@ export default {
   computed: {
     // gives access to this.doubleCounter inside the component
     // same as reading from store.doubleCounter
-    ...mapState(useCounterStore, ['doubleCount']),
+    ...mapState(useCounterStore, ['doubleCounter']),
     // same as above but registers it as this.myOwnName
     ...mapState(useCounterStore, {
       myOwnName: 'doubleCounter',


### PR DESCRIPTION
seems like a typo in the getter name(line no. 227). **doubleCount** should be **doubleCounter** as given in the example(line no. 187)

line no. 225 - 227
```
// gives access to this.doubleCounter inside the component
// same as reading from store.doubleCounter
...mapState(useCounterStore, ['doubleCount'])
```

line no. 187
```
doubleCounter(state) {
    return state.counter * 2
}
```

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
