### PR TITLE
docs: fix typo buildModules to modules for nuxt3

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -10,7 +10,7 @@ yarn add @pinia/nuxt
 npm install @pinia/nuxt
 ```
 
-We supply a _module_ to handle everything for you, you only need to add it to `buildModules` in your `nuxt.config.js` file:
+We supply a _module_ to handle everything for you, you only need to add it to `modules` in your `nuxt.config.js` file:
 
 ```js
 // nuxt.config.js
@@ -47,7 +47,7 @@ By default `@pinia/nuxt` exposes one single auto import: `usePinia()`, which is 
 // nuxt.config.js
 export default {
   // ... other options
-  buildModules: [
+  modules: [
     // ...
     [
       '@pinia/nuxt',

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -45,7 +45,7 @@ By default `@pinia/nuxt` exposes one single auto import: `usePinia()`, which is 
 
 ```js
 // nuxt.config.js
-export default {
+export default defineNuxtConfig({
   // ... other options
   modules: [
     // ...
@@ -61,7 +61,7 @@ export default {
       },
     ],
   ],
-}
+})
 ```
 
 ## Nuxt 2 without bridge


### PR DESCRIPTION
Need to change the prop name buildModules to modules for nuxt3 example
