### PR TITLE
docs: added 'export' keyword for useCounterStore

### DIFF
--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -179,7 +179,7 @@ For the following examples, you can assume the following store was created:
 
 import { defineStore } from 'pinia'
 
-const useCounterStore = defineStore('counter', {
+export const useCounterStore = defineStore('counter', {
   state: () => ({
     count: 0,
   }),


### PR DESCRIPTION
line no. 182 - missing 'export'
`const useCounterStore = defineStore('counter', {
`
line no. 199
`import { useCounterStore } from '../stores/counter'
`
line no. 122 - has 'export'
`export const useStore = defineStore('main', {
`
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
