### PR TITLE
chore: correct composition-api requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 - 🏗 Modular by design
 - 📦 Extremely light
 
-Pinia works both for Vue 2.x and Vue 3.x. It requires Vue 2 with the latest `@vue/composition-api` or Vue `^3.2.0-0`.
+Pinia works with both :-
+- Vue 2.x(For Vue <2.7 latest `@vue/composition-api` also needs to be installed)
+- Vue 3.x(Vue `^3.2.0-0` required)
 
 Pinia is the most similar English pronunciation of the word _pineapple_ in Spanish: _piña_. A pineapple is in reality a group of individual flowers that join together to create a multiple fruit. Similar to stores, each one is born individually, but they are all connected at the end. It's also a delicious tropical fruit indigenous to South America.
 
@@ -122,7 +124,7 @@ yarn add pinia
 npm install pinia
 ```
 
-If you are using Vue 2, make sure to install latest `@vue/composition-api`:
+If you are using Vue <2.7, make sure to install latest `@vue/composition-api`:
 
 ```bash
 npm install pinia @vue/composition-api

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -9,7 +9,7 @@ npm install pinia
 ```
 
 :::tip
-If your app is using Vue <= 2.6.x, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).
+If your app is using Vue <2.7, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).
 :::
 
 If you are using the Vue CLI, you can instead give this [**unofficial plugin**](https://github.com/wobsoriano/vue-cli-plugin-pinia) a try.


### PR DESCRIPTION
since @vue/composition-api is not required for Vue >=2.7

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
