### PR TITLE
build(pinia): remove unused `@vue/devtools-api` require from `pinia.prod.cjs` (#1561) [skip ci]

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,7 +119,11 @@ function createConfig(buildName, output, plugins = []) {
   hasTSChecked = true
 
   const external = ['vue-demi', 'vue', '@vue/composition-api']
-  if (!isGlobalBuild && !(isProductionBuild && isNodeBuild /* pinia.prod.cjs */)) {
+  if (
+    !isGlobalBuild &&
+    // pinia.prod.cjs should not require `@vue/devtools-api` (like Vue)
+    !(isProductionBuild && isNodeBuild)
+  ) {
     external.push('@vue/devtools-api')
   }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,7 +119,7 @@ function createConfig(buildName, output, plugins = []) {
   hasTSChecked = true
 
   const external = ['vue-demi', 'vue', '@vue/composition-api']
-  if (!isGlobalBuild) {
+  if (!isGlobalBuild && !(isProductionBuild && isNodeBuild /* pinia.prod.cjs */)) {
     external.push('@vue/devtools-api')
   }
 
@@ -191,6 +191,7 @@ function createReplacePlugin(
       replacements[key] = process.env[key]
     }
   })
+
   return replace({
     preventAssignment: true,
     values: replacements,


### PR DESCRIPTION
This PR removed unused `require('@vue/devtools-api')` statement in `pinia.prod.cjs`. Probably there is a better workaround and it is a bug in rollup that does not remove external dependency **after treeshake**.