### PR TITLE
docs(nuxt): pinia plugins usage (#1581) [skip ci]

### DIFF
--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -368,7 +368,6 @@ When [using pinia alongside Nuxt](../ssr/nuxt.md), you will have to create a [Nu
 ```ts
 // plugins/myPiniaPlugin.js
 import { PiniaPluginContext } from 'pinia'
-import { Plugin } from '@nuxt/types'
 
 function MyPiniaPlugin({ store }: PiniaPluginContext) {
   store.$subscribe((mutation) => {
@@ -380,11 +379,9 @@ function MyPiniaPlugin({ store }: PiniaPluginContext) {
   return { creationTime: new Date() }
 }
 
-const myPlugin: Plugin = ({ $pinia }) => {
+export default defineNuxtPlugin(({ $pinia }) => {
   $pinia.use(MyPiniaPlugin)
-}
-
-export default myPlugin
+})
 ```
 
 Note the above example is using TypeScript, you have to remove the type annotations `PiniaPluginContext` and `Plugin` as well as their imports if you are using a `.js` file.

--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -385,3 +385,27 @@ export default defineNuxtPlugin(({ $pinia }) => {
 ```
 
 Note the above example is using TypeScript, you have to remove the type annotations `PiniaPluginContext` and `Plugin` as well as their imports if you are using a `.js` file.
+
+### Nuxt.js 2
+
+```ts
+// plugins/myPiniaPlugin.js
+import { PiniaPluginContext } from 'pinia'
+import { Plugin } from '@nuxt/types'
+
+function MyPiniaPlugin({ store }: PiniaPluginContext) {
+  store.$subscribe((mutation) => {
+    // react to store changes
+    console.log(`[🍍 ${mutation.storeId}]: ${mutation.type}.`)
+  })
+
+  // Note this has to be typed if you are using TS
+  return { creationTime: new Date() }
+}
+
+const myPlugin: Plugin = ({ $pinia }) => {
+  $pinia.use(MyPiniaPlugin)
+}
+
+export default myPlugin
+```


### PR DESCRIPTION
when use `export default myPlugin`, it got a nuxt3 warning following
```bash
[warn] [nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements: myPlugin
```
it recommended to use
```ts
export default defineNuxtPlugin(({ $pinia }) => {
  $pinia.use(MyPiniaPlugin)
})
```

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
