### PR TITLE
docs: fix a typo in the `pinia._StoreOnActionListenerContext.md` file

### DIFF
--- a/packages/docs/api/interfaces/pinia._StoreOnActionListenerContext.md
+++ b/packages/docs/api/interfaces/pinia._StoreOnActionListenerContext.md
@@ -72,7 +72,7 @@ ___
 ▸ (`callback`): `void`
 
 Sets up a hook if the action fails. Return `false` to catch the error and
-stop it fro propagating.
+stop it from propagating.
 
 ##### Parameters
 


### PR DESCRIPTION
Fellows, in this pull request, I send to merge a typing correction
that I did in the `pinia._StoreOnActionListenerContext.md` file.

It can seem an insignificant change, but necessary if we want to
keep a good and understandable documentation.