### PR TITLE
docs(ssr): fix skipHydrate references undefined ref

### DIFF
--- a/packages/docs/cookbook/composables.md
+++ b/packages/docs/cookbook/composables.md
@@ -91,7 +91,7 @@ export const useColorStore = defineStore('colors', () => {
   const lastColor = useLocalStorage('lastColor', sRGBHex)
   // ...
   return {
-    lastColor: skipHydrate(pickedColor), // Ref<string>
+    lastColor: skipHydrate(lastColor), // Ref<string>
     open, // Function
     isSupported, // boolean (not even reactive)
   }


### PR DESCRIPTION
it seems `pickedColor` in example is an undefined variable