### PR TITLE
fix(store): avoid prototype pollution

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -68,7 +68,7 @@ function mergeReactiveObjects<T extends StateTree>(
 
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!patchToApply.hasOwnProperty(key)) continue
+    if (!target.hasOwnProperty(key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
     if (


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
```js
for (const key in patchToApply) {
  if (!patchToApply.hasOwnProperty(key)) continue
  ...
}
```
```js
if (!patchToApply.hasOwnProperty(key)) continue
```
always return false,can't avoid prototype pollution