### PR TITLE
feat: warn developers for duplicated store keys

### DIFF
--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -101,7 +101,7 @@ describe('Store', () => {
 
   it('can create an empty state if no state option is provided', () => {
     const store = defineStore({ id: 'some' })()
-    
+
     expect(store.$state).toEqual({})
   })
 
@@ -380,7 +380,7 @@ describe('Store', () => {
     ).toHaveBeenWarnedTimes(1)
   })
 
-  it.only('warns when creating store with existing id', async () => {
+  it('warns when creating store with existing id', async () => {
     const storeId = 'testStoreID';
     const useFirstStore = defineStore(storeId, {});
     const useSecondStore = defineStore(storeId, {});

--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -101,7 +101,7 @@ describe('Store', () => {
 
   it('can create an empty state if no state option is provided', () => {
     const store = defineStore({ id: 'some' })()
-
+    
     expect(store.$state).toEqual({})
   })
 
@@ -379,4 +379,16 @@ describe('Store', () => {
       `[🍍]: A getter cannot have the same name as another state property. Rename one of them. Found with "anyName" in store "main".`
     ).toHaveBeenWarnedTimes(1)
   })
+
+  it.only('warns when creating store with existing id', async () => {
+    const storeId = 'testStoreID';
+    const useFirstStore = defineStore(storeId, {});
+    const useSecondStore = defineStore(storeId, {});
+    useFirstStore();
+    useSecondStore();
+
+    expect(
+      `[🍍]: Stores should have unique identifiers. Found multiple stores with id "testStoreID". Rename one of them.`
+    ).toHaveBeenWarned();
+  });
 })

--- a/packages/pinia/src/createPinia.ts
+++ b/packages/pinia/src/createPinia.ts
@@ -52,6 +52,7 @@ export function createPinia(): Pinia {
     _a: null,
     _e: scope,
     _s: new Map<string, StoreGeneric>(),
+    _k: [],
     state,
   })
 

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -86,6 +86,14 @@ export interface Pinia {
   _s: Map<string, StoreGeneric>
 
   /**
+   * Registry of store ids defined in this pinia instance.
+   * This is used to check for duplicated keys.
+   * 
+   * @internal
+   */
+  _k: Array<string>
+
+  /**
    * Added by `createTestingPinia()` to bypass `useStore(pinia)`.
    *
    * @internal

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -880,6 +880,14 @@ export function defineStore(
     id = idOrOptions.id
   }
 
+  // Warn developers about existing store ID in dev environments
+  if (__DEV__ && activePinia?._k.includes(id)) {
+    console.warn(`[🍍]: Stores should have unique identifiers. Found multiple stores with id "${id}". Rename one of them.`)
+  }
+
+  // Push ID to keys registry
+  activePinia?._k.push(id)
+
   function useStore(pinia?: Pinia | null, hot?: StoreGeneric): StoreGeneric {
     const currentInstance = getCurrentInstance()
     pinia =


### PR DESCRIPTION
Another attempt to contribute to #1394 🙂

In tests, I'm getting various warnings because those tests are using duplicated names for stores. I'm not sure how to approach this in a smart way, appreciate any help or feedback.

Tried this approach to avoid messing with `._s` registry property. What are your thoughts?

Closes #1394 
