### PR TITLE
docs: remove anchor tag by markdown plugins.

### DIFF
--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -1,5 +1,7 @@
 // @ts-check
 import locales from './locales'
+import renderPermaLink from './render-perma-link'
+import MarkDownItCustomAnchor from './markdown-it-custom-anchor'
 
 const META_URL = 'https://pinia.vuejs.org'
 const META_TITLE = 'Pinia 🍍'
@@ -32,6 +34,12 @@ module.exports = {
       leftDelimiter: '%{',
       rightDelimiter: '}%',
     },
+    anchor: {
+      permalink: renderPermaLink,
+    },
+    config: (md) => {
+      md.use(MarkDownItCustomAnchor)
+    }
   },
   locales: locales.vitepressConfig,
 

--- a/packages/docs/.vitepress/markdown-it-custom-anchor/index.js
+++ b/packages/docs/.vitepress/markdown-it-custom-anchor/index.js
@@ -1,0 +1,25 @@
+const anchorMatch = /^.+(\s*\{#([a-z0-9\-_]+?)\}\s*)$/;
+
+const removeAnchorFromTitle = (oldTitle) => {
+  const match = anchorMatch.exec(oldTitle);
+  return match ? oldTitle.replace(match[1], '').trim() : oldTitle;
+}
+
+export default function(md) {
+  const oldTitle = md.renderer.rules.text;
+  md.renderer.rules.text = (tokens, idx, options, env, slf) => {
+    const titleAndId = oldTitle(tokens, idx, options, env, slf);
+    return removeAnchorFromTitle(titleAndId);
+  };
+
+  const oldHeading = md.renderer.rules.heading_open;
+  md.renderer.rules.heading_open = (tokens, idx, options, env, slf) => {
+    const head = oldHeading(tokens, idx, options, env, slf);
+    const data = md.__data;
+    const headers = data.headers || (data.headers = []);
+    headers.forEach(element => {
+      element.title = removeAnchorFromTitle(element.title);
+    });
+    return head;
+  }
+};

--- a/packages/docs/.vitepress/render-perma-link/index.js
+++ b/packages/docs/.vitepress/render-perma-link/index.js
@@ -1,0 +1,37 @@
+const position = {
+  false: 'push',
+  true: 'unshift'
+}
+
+const renderPermalink = (slug, opts, state, permalink) => {
+  try {
+    const tokens = state.tokens
+    const token = tokens[permalink]
+    const title = tokens[permalink + 1]
+      .children
+      .filter(token => token.type === 'text' || token.type === 'code_inline')
+      .reduce((acc, t) => acc + t.content, '')
+    const match = /^.+(\s*\{#([a-z0-9\-_]+?)\}\s*)$/.exec(title);
+    slug = match ? match[2] : slug;
+    token.attrSet('id', slug)
+    const space = () => Object.assign(new state.Token('text', '', 0), { content: ' ' })
+
+    const linkTokens = [
+      Object.assign(new state.Token('link_open', 'a', 1), {
+        attrs: [
+          ...(opts.permalinkClass ? [['class', opts.permalinkClass]] : []),
+          ['href', opts.permalinkHref(slug, state)],
+          ...Object.entries(opts.permalinkAttrs(slug, state))
+        ]
+      }),
+      Object.assign(new state.Token('html_block', '', 0), { content: opts.permalinkSymbol }),
+      new state.Token('link_close', 'a', -1)
+    ]
+    if (opts.permalinkSpace) {
+      linkTokens[position[!opts.permalinkBefore]](space())
+    }
+    state.tokens[permalink + 1].children[position[opts.permalinkBefore]](...linkTokens)
+  } catch(e) {}
+}
+
+export default renderPermalink


### PR DESCRIPTION
Hi, I am the maintainer of Vite.js [docs-cn](https://github.com/vitejs/docs-cn). I found that the new Chinese translation of Pinia here these days. Nice job and shout out for @KimYangOfCat's great effort ❤️

I've noticed that there're still `{#xxx}` anchor tag remaining on `h1~h6` titles. **It is not a bug, it's a feature. we provide this mechanism in Vite's Chinese docs and Vuejs Chinese docs, and it's a general solution for anchor normalization.**

I'm here to help, and we just need two markdown-it plugins, as I submitted in this PR.

These two plugins is also used in the following repo:

**Vite Chinese docs**:
- https://github.com/vitejs/docs-cn/tree/main/.vitepress/render-perma-link/indes.js
- https://github.com/vitejs/docs-cn/tree/main/.vitepress/markdown-it-custom-anchor/index.js

**Vue.js Chinese docs**:
- https://github.com/vuejs-translations/docs-zh-cn/blob/main/.vitepress/headerMdPlugin.ts ( which has basically the same meaning )

Also, we can close #1732 after merging.

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/46062972/196589555-38f1a7cf-ad33-4e2d-a60c-43497640a612.png">
