### PR TITLE
feat: resetAllStores helper for resetting all previously injects stores

### DIFF
--- a/packages/pinia/__tests__/resetAllStores.spec.ts
+++ b/packages/pinia/__tests__/resetAllStores.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+
+import { createPinia, defineStore, setActivePinia, Pinia } from '../src'
+import { resetAllStores } from '../src/resetAllStores'
+
+describe('createPinia', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  const useA = defineStore({
+    id: 'A',
+    state: () => ({}),
+  })
+
+  const useB = defineStore({
+    id: 'B',
+    state: () => ({}),
+  })
+
+  it('resets all stores', () => {
+    const stores = [useA(), useB()]
+
+    stores.forEach((store) => {
+      store.$reset = vi.fn()
+    })
+    resetAllStores()
+
+    stores.forEach((store) => {
+      expect(store.$reset).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/pinia/__tests__/resetAllStores.spec.ts
+++ b/packages/pinia/__tests__/resetAllStores.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { createPinia, defineStore, setActivePinia, Pinia } from '../src'
 import { resetAllStores } from '../src/resetAllStores'
 
-describe('createPinia', () => {
+describe('resetAllStores', () => {
   let pinia: Pinia
 
   beforeEach(() => {

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -63,6 +63,7 @@ export {
 } from './mapHelpers'
 
 export { storeToRefs } from './storeToRefs'
+export { resetAllStores } from './resetAllStores'
 
 export type {
   MapStoresCustomization,

--- a/packages/pinia/src/resetAllStores.ts
+++ b/packages/pinia/src/resetAllStores.ts
@@ -1,0 +1,12 @@
+import { getActivePinia } from './rootStore'
+
+/**
+ * Resets all injected stores
+ */
+export function resetAllStores() {
+  const pinia = getActivePinia()
+
+  pinia?._s.forEach((store) => {
+    store.$reset()
+  })
+}


### PR DESCRIPTION
For now, there is no possibility to reset all stores at once that were previously injected and used in the app. This PR introduces a new helper that allows resetting all the stores.
