### PR TITLE
fix(nuxt): Avoid recursive import from Nuxt #imports

### DIFF
--- a/packages/nuxt/src/runtime/composables.ts
+++ b/packages/nuxt/src/runtime/composables.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from '#imports'
+import { useNuxtApp } from '#app'
 export * from 'pinia'
 
 export const usePinia = () => useNuxtApp().$pinia


### PR DESCRIPTION
Since `runtime/composable.ts` is added to Nuxt `#imports`, we shouldn't use this import to define the composable. Without this fix, WebStorm is unable to analyze files importing Nuxt's `#imports` file and Vitest runs indefinitely.