### PR TITLE
docs: basic defineStore example follows return value naming rec

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -14,7 +14,7 @@ import { defineStore } from 'pinia'
 // but it's best to use the name of the store and surround it with `use` 
 // and `Store` (e.g. `useUserStore`, `useCartStore`, `useProductStore`)
 // the first argument is a unique id of the store across your application
-export const useStore = defineStore('main', {
+export const useMainStore = defineStore('main', {
   // other options...
 })
 ```

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -14,7 +14,7 @@ import { defineStore } from 'pinia'
 // but it's best to use the name of the store and surround it with `use` 
 // and `Store` (e.g. `useUserStore`, `useCartStore`, `useProductStore`)
 // the first argument is a unique id of the store across your application
-export const useMainStore = defineStore('main', {
+export const useAlertsStore = defineStore('alerts', {
   // other options...
 })
 ```


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

In the first example at https://pinia.vuejs.org/core-concepts/#defining-a-store, we are told

> You can name the return value of `defineStore()` anything you want, but it's best to use the name of the store and surround it with `use` and `Store` (e.g. `useUserStore`, `useCartStore`, `useProductStore`)

but the example itself is `…useStore = defineStore('main',…` not `…useMainStore = defineStore('main',…`

This updates the example to follow its own recommended naming convention.