### PR TITLE
fix(peer-deps): re-declaring peer-dependency of vue-demi

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -50,7 +50,8 @@
     "siroc": "^0.16.0"
   },
   "peerDependencies": {
-    "pinia": ">=2.0.19"
+    "pinia": ">=2.0.19",
+    "vue": "^3.0.0-0 || ^2.6.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When yarn installing this package, I receive the following error:
```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @pinia/testing@npm:0.0.14 [329d6] doesn't provide vue (pa561a), requested by vue-demi
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed
```
Which then yields the following message when running `yarn explain peer-requirements pa561a`
```
➤YN0000: @pinia/testing@npm:0.0.14 [329d6] doesn't provide vue, breaking the following requirements:
➤YN0000: vue-demi@npm:0.13.11 [e1ef3] → ^3.0.0-0 || ^2.6.0 ✘
```

It is customary to re-export the peer-dependencies of your dependencies so that consumers of @pinia/testing are able to identify what the peer dependency requirements are at a glance instead of needing to traverse the entire dependency graph to figure that out. The required version range here was taken from the latest release of vue-demi, but since the vue-demi dependency used here is *, it might be more appropriate to also just list the vue peer dependency version as *.

In the meantime, I was able to work around this issue by setting the following in my .yarnrc.yml:
```yaml
packageExtensions:
  "@pinia/testing@*":
    peerDependencies:      
      "vue": "*"