### PR TITLE
feat(getters): add example with illegal(?) getter modification

### DIFF
--- a/packages/pinia/__tests__/pinia/stores/objectStore.ts
+++ b/packages/pinia/__tests__/pinia/stores/objectStore.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { Ref, ref, ComputedRef, computed } from 'vue'
+
+export interface ObjectyState {
+  didChangeIllegally: boolean
+  didChangeLegally: boolean
+}
+
+export const useObjectStore = defineStore('testStore', () => {
+  const testStatePrivate: Ref<ObjectyState> = ref({
+    didChangeIllegally: false,
+    didChangeLegally: false,
+  })
+
+  const testStateGetter: ComputedRef<ObjectyState> = computed(() => {
+    return { ...testStatePrivate.value }
+  })
+
+  function modifyLegalValue(newValue: boolean) {
+    testStatePrivate.value.didChangeLegally = newValue
+  }
+
+  return { testStateGetter, modifyLegalValue }
+})


### PR DESCRIPTION
Should it be illegal to modify a ref created from getter?

This PR is an example related to https://github.com/vuejs/pinia/issues/1851