### PR TITLE
build: replace yarn to pnpm

### DIFF
--- a/packages/size-check/package.json
+++ b/packages/size-check/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "scripts": {
     "build:size": "rollup -c rollup.config.js",
-    "size": "yarn run build:size && yarn run size:check",
+    "size": "pnpm run build:size && pnpm run size:check",
     "size:check": "node scripts/check-size.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
```bash
> pnpm run -r size

Scope: 6 of 7 workspace projects
packages/size-check size$ yarn run build:size && yarn run size:check
│ Usage Error: This project is configured to use pnpm
│ $ yarn ...
└─ Failed in 60ms
```
change usage to pnpm

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
