### PR TITLE
Fix code snippet error

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -56,7 +56,8 @@ export default defineNuxtConfig({
           // automatically imports `defineStore`
           'defineStore', // import { defineStore } from 'pinia'
           // automatically imports `defineStore` as `definePiniaStore`
-          ['defineStore', 'definePiniaStore'], // import { defineStore as definePiniaStore } from 'pinia'
+          // or
+          'defineStore', 'definePiniaStore', // import { defineStore as definePiniaStore } from 'pinia'
         ],
       },
     ],


### PR DESCRIPTION
The current snippet implies there is another array inside the `autoImports` array and readers/users that copy and paste (like me) might have a hard time spotting  why their Store isn't working as expected. It also suggests that it is either `defineStore` or `'defineStore', 'definePiniaStore'` and not both.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
