### PR TITLE
docs: installation workaround npm

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -10,6 +10,16 @@ yarn add pinia @pinia/nuxt
 npm install pinia @pinia/nuxt
 ```
 
+:::tip 
+If you're using **npm**, `ERESOLVE unable to resolve dependency tree` error may happen when trying to `npm install` pinia into Nuxt project. This can be fixed by adding the following into your `package.json`:
+
+```js
+"overrides": { 
+  "vue": "latest"
+}
+```
+:::
+
 We supply a _module_ to handle everything for you, you only need to add it to `modules` in your `nuxt.config.js` file:
 
 ```js
@@ -24,16 +34,6 @@ export default defineNuxtConfig({
 ```
 
 And that's it, use your store as usual!
-
-:::tip 
-If you're using **npm**, `ERESOLVE unable to resolve dependency tree` error may happen when trying to `npm install` pinia into Nuxt project. This can be fixed by adding the following into your `package.json`:
-
-```js
-"overrides": { 
-     "vue": "latest"
-}
-```
-:::
 
 ## Using the store outside of `setup()`
 

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -11,7 +11,7 @@ npm install pinia @pinia/nuxt
 ```
 
 :::tip 
-If you're using **npm**, `ERESOLVE unable to resolve dependency tree` error may happen when trying to `npm install` pinia into Nuxt project. This can be fixed by adding the following into your `package.json`:
+If you're using npm, you might encounter an _ERESOLVE unable to resolve dependency tree_ error. In that case, add the following to your `package.json`:
 
 ```js
 "overrides": { 

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -25,21 +25,15 @@ export default defineNuxtConfig({
 
 And that's it, use your store as usual!
 
-### NPM dependency issue with Nuxt 3
-
-As of late December 2022 there is a [known problem](https://github.com/vuejs/pinia/issues/853) that may emerge when running `npm install`. You may end up with following error:
-
-```
-ERESOLVE unable to resolve dependency tree
-```
-
-There is nothing actually wrong with the setup, the problem lies inside npm. However, you can easilly bypass it with adding the following into your `package.json`:
+:::tip 
+If you're using **npm**, `ERESOLVE unable to resolve dependency tree` error may happen when trying to `npm install` pinia into Nuxt project. This can be fixed by adding the following into your `package.json`:
 
 ```js
 "overrides": { 
-    "vue": "latest"
+     "vue": "latest"
 }
 ```
+:::
 
 ## Using the store outside of `setup()`
 

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -25,6 +25,22 @@ export default defineNuxtConfig({
 
 And that's it, use your store as usual!
 
+### NPM dependency issue with Nuxt 3
+
+As of late December 2022 there is a [known problem](https://github.com/vuejs/pinia/issues/853) that may emerge when running `npm install`. You may end up with following error:
+
+```
+ERESOLVE unable to resolve dependency tree
+```
+
+There is nothing actually wrong with the setup, the problem lies inside npm. However, you can easilly bypass it with adding the following into your `package.json`:
+
+```js
+"overrides": { 
+    "vue": "latest"
+}
+```
+
 ## Using the store outside of `setup()`
 
 If you want to use a store outside of `setup()`, remember to pass the `pinia` object to `useStore()`. We added it to [the context](https://nuxtjs.org/docs/2.x/internals-glossary/context) so you have access to it in `asyncData()` and `fetch()`:


### PR DESCRIPTION
Because people keep running into https://github.com/vuejs/pinia/issues/853 I'd suggest to include the troubleshoting directly inside the docs

Close #853