### PR TITLE
docs(ja): add ja-JP translation

### DIFF
--- a/packages/docs/.vitepress/components/VueSchoolLink.vue
+++ b/packages/docs/.vitepress/components/VueSchoolLink.vue
@@ -18,6 +18,7 @@ const { site } = useData()
 const translations = {
   'en-US': 'Watch a free video lesson on Vue School',
   'zh-CN': '在 Vue School 上观看免费视频课程',
+  'ja-JP': 'Watch a free video lesson on Vue School',
 }
 defineProps<{ href: string; title: string }>()
 </script>

--- a/packages/docs/.vitepress/locales/index.js
+++ b/packages/docs/.vitepress/locales/index.js
@@ -1,13 +1,16 @@
 import en from './en.js'
 import zh from './zh.js'
+import ja from './ja'
 
 export default {
   vitepressConfig: {
     '/': en.vitepressConfig,
     '/zh/': zh.vitepressConfig,
+    '/ja/': ja.vitepressConfig,
   },
   themeConfig: {
     '/': en.themeConfig,
     '/zh/': zh.themeConfig,
+    '/ja/': ja.themeConfig,
   },
 }

--- a/packages/docs/.vitepress/locales/ja.js
+++ b/packages/docs/.vitepress/locales/ja.js
@@ -1,5 +1,4 @@
 export default {
-  appearance: 'dark',
   vitepressConfig: {
     title: 'Pinia',
     lang: 'ja-JP',

--- a/packages/docs/.vitepress/locales/ja.js
+++ b/packages/docs/.vitepress/locales/ja.js
@@ -1,0 +1,135 @@
+export default {
+  appearance: 'dark',
+  vitepressConfig: {
+    title: 'Pinia',
+    lang: 'ja-JP',
+    description: 'The Vue Store that you will enjoy using',
+  },
+  themeConfig: {
+    label: '日本語',
+    selectText: 'Languages',
+    editLinkText: 'このページの変更を提案',
+    lastUpdated: 'Last Updated',
+
+    nav: [
+      { text: 'Guide', link: '/ja/introduction.html' },
+      { text: 'API', link: '/ja/api/' },
+      // { text: 'Config', link: '/ja/config/' },
+      // { text: 'Plugins', link: '/ja/plugins/' },
+      {
+        text: 'Links',
+        items: [
+          {
+            text: 'Discussions',
+            link: 'https://github.com/vuejs/pinia/discussions',
+          },
+          {
+            text: 'Chat',
+            link: 'https://chat.vuejs.org',
+          },
+          {
+            text: 'Twitter',
+            link: 'https://twitter.com/posva',
+          },
+          {
+            text: 'Changelog',
+            link: 'https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md',
+          },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/ja/api/': [
+        {
+          text: 'packages',
+          children: [
+            { text: 'pinia', link: '/ja/api/modules/pinia.html' },
+            { text: '@pinia/nuxt', link: '/ja/api/modules/pinia_nuxt.html' },
+            {
+              text: '@pinia/testing',
+              link: '/ja/api/modules/pinia_testing.html',
+            },
+          ],
+        },
+      ],
+      // catch-all fallback
+      '/ja/': [
+        {
+          text: 'Introduction',
+          children: [
+            {
+              text: 'What is Pinia? 🇯🇵',
+              link: '/ja/introduction.html',
+            },
+            {
+              text: 'Getting Started 🇯🇵',
+              link: '/ja/getting-started.html',
+            },
+          ],
+        },
+        {
+          text: 'Core Concepts',
+          children: [
+            { text: 'Defining a Store 🇯🇵', link: '/ja/core-concepts/' },
+            { text: 'State 🇯🇵', link: '/ja/core-concepts/state.html' },
+            { text: 'Getters 🇯🇵', link: '/ja/core-concepts/getters.html' },
+            { text: 'Actions 🇯🇵', link: '/ja/core-concepts/actions.html' },
+            { text: 'Plugins', link: '/ja/core-concepts/plugins.html' },
+            {
+              text: 'Stores outside of components 🇯🇵',
+              link: '/ja/core-concepts/outside-component-usage.html',
+            },
+          ],
+        },
+        {
+          text: 'Server-Side Rendering (SSR)',
+          children: [
+            {
+              text: 'Vue and Vite',
+              link: '/ja/ssr/',
+            },
+            {
+              text: 'Nuxt.js',
+              link: '/ja/ssr/nuxt.html',
+            },
+          ],
+        },
+        {
+          text: 'Cookbook',
+          link: '/ja/cookbook/',
+          children: [
+            {
+              text: 'Migration from Vuex ≤4',
+              link: '/ja/cookbook/migration-vuex.html',
+            },
+            {
+              text: 'Hot Module Replacement 🇯🇵',
+              link: '/ja/cookbook/hot-module-replacement.html',
+            },
+            {
+              text: 'Testing 🇯🇵',
+              link: '/ja/cookbook/testing.html',
+            },
+            {
+              text: 'Usage without setup()',
+              link: '/ja/cookbook/options-api.html',
+            },
+            {
+              text: 'Composing Stores 🇯🇵',
+              link: '/ja/cookbook/composing-stores.html',
+            },
+            {
+              text: 'Migration from v0/v1 to v2',
+              link: '/ja/cookbook/migration-v1-v2.html',
+            },
+            {
+              text: 'Dealing with composables 🇯🇵',
+              link: '/ja/cookbook/composables.html',
+            },
+          ],
+        },
+      ],
+    },
+  },
+}

--- a/packages/docs/ja/api/enums/pinia.MutationType.md
+++ b/packages/docs/ja/api/enums/pinia.MutationType.md
@@ -1,0 +1,45 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / MutationType
+
+# Enumeration: MutationType
+
+[pinia](../modules/pinia.md).MutationType
+
+Possible types for SubscriptionCallback
+
+## Enumeration Members
+
+### direct
+
+• **direct** = ``"direct"``
+
+Direct mutation of the state:
+
+- `store.name = 'new name'`
+- `store.$state.name = 'new name'`
+- `store.list.push('new item')`
+
+___
+
+### patchFunction
+
+• **patchFunction** = ``"patch function"``
+
+Mutated the state with `$patch` and a function
+
+- `store.$patch(state => state.name = 'newName')`
+
+___
+
+### patchObject
+
+• **patchObject** = ``"patch object"``
+
+Mutated the state with `$patch` and an object
+
+- `store.$patch({ name: 'newName' })`

--- a/packages/docs/ja/api/index.md
+++ b/packages/docs/ja/api/index.md
@@ -1,0 +1,9 @@
+API Documentation
+
+# API Documentation
+
+## Modules
+
+- [@pinia/nuxt](modules/pinia_nuxt.md)
+- [@pinia/testing](modules/pinia_testing.md)
+- [pinia](modules/pinia.md)

--- a/packages/docs/ja/api/interfaces/pinia.DefineSetupStoreOptions.md
+++ b/packages/docs/ja/api/interfaces/pinia.DefineSetupStoreOptions.md
@@ -1,0 +1,43 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineSetupStoreOptions
+
+# Interface: DefineSetupStoreOptions<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).DefineSetupStoreOptions
+
+Options parameter of `defineStore()` for setup stores. Can be extended to
+augment stores with the plugin API.
+
+**`See`**
+
+[DefineStoreOptionsBase](pinia.DefineStoreOptionsBase.md).
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+## Hierarchy
+
+- [`DefineStoreOptionsBase`](pinia.DefineStoreOptionsBase.md)<`S`, [`Store`](../modules/pinia.md#store)<`Id`, `S`, `G`, `A`\>\>
+
+  ↳ **`DefineSetupStoreOptions`**
+
+## Properties
+
+### actions
+
+• `Optional` **actions**: `A`
+
+Extracted actions. Added by useStore(). SHOULD NOT be added by the user when
+creating the store. Can be used in plugins to get the list of actions in a
+store defined with a setup function. Note this is always defined

--- a/packages/docs/ja/api/interfaces/pinia.DefineStoreOptions.md
+++ b/packages/docs/ja/api/interfaces/pinia.DefineStoreOptions.md
@@ -1,0 +1,112 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptions
+
+# Interface: DefineStoreOptions<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).DefineStoreOptions
+
+Options parameter of `defineStore()` for option stores. Can be extended to
+augment stores with the plugin API.
+
+**`See`**
+
+[DefineStoreOptionsBase](pinia.DefineStoreOptionsBase.md).
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+## Hierarchy
+
+- [`DefineStoreOptionsBase`](pinia.DefineStoreOptionsBase.md)<`S`, [`Store`](../modules/pinia.md#store)<`Id`, `S`, `G`, `A`\>\>
+
+  ↳ **`DefineStoreOptions`**
+
+## Properties
+
+### actions
+
+• `Optional` **actions**: `A` & `ThisType`<`A` & `UnwrapRef`<`S`\> & [`_StoreWithState`](pinia._StoreWithState.md)<`Id`, `S`, `G`, `A`\> & [`_StoreWithGetters`](../modules/pinia.md#_storewithgetters)<`G`\> & [`PiniaCustomProperties`](pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\>\>
+
+Optional object of actions.
+
+___
+
+### getters
+
+• `Optional` **getters**: `G` & `ThisType`<`UnwrapRef`<`S`\> & [`_StoreWithGetters`](../modules/pinia.md#_storewithgetters)<`G`\> & [`PiniaCustomProperties`](pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\>\> & [`_GettersTree`](../modules/pinia.md#_getterstree)<`S`\>
+
+Optional object of getters.
+
+___
+
+### id
+
+• **id**: `Id`
+
+Unique string key to identify the store across the application.
+
+___
+
+### state
+
+• `Optional` **state**: () => `S`
+
+#### Type declaration
+
+▸ (): `S`
+
+Function to create a fresh state. **Must be an arrow function** to ensure
+correct typings!
+
+##### Returns
+
+`S`
+
+## Methods
+
+### hydrate
+
+▸ `Optional` **hydrate**(`storeState`, `initialState`): `void`
+
+Allows hydrating the store during SSR when complex state (like client side only refs) are used in the store
+definition and copying the value from `pinia.state` isn't enough.
+
+**`Example`**
+
+If in your `state`, you use any `customRef`s, any `computed`s, or any `ref`s that have a different value on
+Server and Client, you need to manually hydrate them. e.g., a custom ref that is stored in the local
+storage:
+
+```ts
+const useStore = defineStore('main', {
+  state: () => ({
+    n: useLocalStorage('key', 0)
+  }),
+  hydrate(storeState, initialState) {
+    // @ts-expect-error: https://github.com/microsoft/TypeScript/issues/43826
+    storeState.n = useLocalStorage('key', 0)
+  }
+})
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `storeState` | `UnwrapRef`<`S`\> | the current state in the store |
+| `initialState` | `UnwrapRef`<`S`\> | initialState |
+
+#### Returns
+
+`void`

--- a/packages/docs/ja/api/interfaces/pinia.DefineStoreOptionsBase.md
+++ b/packages/docs/ja/api/interfaces/pinia.DefineStoreOptionsBase.md
@@ -1,0 +1,30 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptionsBase
+
+# Interface: DefineStoreOptionsBase<S, Store\>
+
+[pinia](../modules/pinia.md).DefineStoreOptionsBase
+
+Options passed to `defineStore()` that are common between option and setup
+stores. Extend this interface if you want to add custom options to both kinds
+of stores.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `Store` | `Store` |
+
+## Hierarchy
+
+- **`DefineStoreOptionsBase`**
+
+  ↳ [`DefineStoreOptions`](pinia.DefineStoreOptions.md)
+
+  ↳ [`DefineSetupStoreOptions`](pinia.DefineSetupStoreOptions.md)

--- a/packages/docs/ja/api/interfaces/pinia.DefineStoreOptionsInPlugin.md
+++ b/packages/docs/ja/api/interfaces/pinia.DefineStoreOptionsInPlugin.md
@@ -1,0 +1,113 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptionsInPlugin
+
+# Interface: DefineStoreOptionsInPlugin<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).DefineStoreOptionsInPlugin
+
+Available `options` when creating a pinia plugin.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+## Hierarchy
+
+- `Omit`<[`DefineStoreOptions`](pinia.DefineStoreOptions.md)<`Id`, `S`, `G`, `A`\>, ``"id"`` \| ``"actions"``\>
+
+  ↳ **`DefineStoreOptionsInPlugin`**
+
+## Properties
+
+### actions
+
+• **actions**: `A`
+
+Extracted object of actions. Added by useStore() when the store is built
+using the setup API, otherwise uses the one passed to `defineStore()`.
+Defaults to an empty object if no actions are defined.
+
+___
+
+### getters
+
+• `Optional` **getters**: `G` & `ThisType`<`UnwrapRef`<`S`\> & [`_StoreWithGetters`](../modules/pinia.md#_storewithgetters)<`G`\> & [`PiniaCustomProperties`](pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\>\> & [`_GettersTree`](../modules/pinia.md#_getterstree)<`S`\>
+
+Optional object of getters.
+
+#### Inherited from
+
+Omit.getters
+
+___
+
+### state
+
+• `Optional` **state**: () => `S`
+
+#### Type declaration
+
+▸ (): `S`
+
+Function to create a fresh state. **Must be an arrow function** to ensure
+correct typings!
+
+##### Returns
+
+`S`
+
+#### Inherited from
+
+Omit.state
+
+## Methods
+
+### hydrate
+
+▸ `Optional` **hydrate**(`storeState`, `initialState`): `void`
+
+Allows hydrating the store during SSR when complex state (like client side only refs) are used in the store
+definition and copying the value from `pinia.state` isn't enough.
+
+**`Example`**
+
+If in your `state`, you use any `customRef`s, any `computed`s, or any `ref`s that have a different value on
+Server and Client, you need to manually hydrate them. e.g., a custom ref that is stored in the local
+storage:
+
+```ts
+const useStore = defineStore('main', {
+  state: () => ({
+    n: useLocalStorage('key', 0)
+  }),
+  hydrate(storeState, initialState) {
+    // @ts-expect-error: https://github.com/microsoft/TypeScript/issues/43826
+    storeState.n = useLocalStorage('key', 0)
+  }
+})
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `storeState` | `UnwrapRef`<`S`\> | the current state in the store |
+| `initialState` | `UnwrapRef`<`S`\> | initialState |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.hydrate

--- a/packages/docs/ja/api/interfaces/pinia.MapStoresCustomization.md
+++ b/packages/docs/ja/api/interfaces/pinia.MapStoresCustomization.md
@@ -1,0 +1,16 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / MapStoresCustomization
+
+# Interface: MapStoresCustomization
+
+[pinia](../modules/pinia.md).MapStoresCustomization
+
+Interface to allow customizing map helpers. Extend this interface with the
+following properties:
+
+- `suffix`: string. Affects the suffix of `mapStores()`, defaults to `Store`.

--- a/packages/docs/ja/api/interfaces/pinia.Pinia.md
+++ b/packages/docs/ja/api/interfaces/pinia.Pinia.md
@@ -1,0 +1,65 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / Pinia
+
+# Interface: Pinia
+
+[pinia](../modules/pinia.md).Pinia
+
+Every application must own its own pinia to be able to create stores
+
+## Hierarchy
+
+- **`Pinia`**
+
+  ↳ [`TestingPinia`](pinia_testing.TestingPinia.md)
+
+## Properties
+
+### install
+
+• **install**: (`app`: `App`<`any`\>) => `void`
+
+#### Type declaration
+
+▸ (`app`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `app` | `App`<`any`\> |
+
+##### Returns
+
+`void`
+
+___
+
+### state
+
+• **state**: `Ref`<`Record`<`string`, [`StateTree`](../modules/pinia.md#statetree)\>\>
+
+root state
+
+## Methods
+
+### use
+
+▸ **use**(`plugin`): [`Pinia`](pinia.Pinia.md)
+
+Adds a store plugin to extend every store
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `plugin` | [`PiniaPlugin`](pinia.PiniaPlugin.md) | store plugin to add |
+
+#### Returns
+
+[`Pinia`](pinia.Pinia.md)

--- a/packages/docs/ja/api/interfaces/pinia.PiniaCustomProperties.md
+++ b/packages/docs/ja/api/interfaces/pinia.PiniaCustomProperties.md
@@ -1,0 +1,44 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / PiniaCustomProperties
+
+# Interface: PiniaCustomProperties<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).PiniaCustomProperties
+
+Interface to be extended by the user when they add properties through plugins.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` = `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) = [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | [`_GettersTree`](../modules/pinia.md#_getterstree)<`S`\> |
+| `A` | [`_ActionsTree`](../modules/pinia.md#_actionstree) |
+
+## Accessors
+
+### route
+
+• `get` **route**(): `RouteLocationNormalized`
+
+#### Returns
+
+`RouteLocationNormalized`
+
+• `set` **route**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `RouteLocationNormalizedLoaded` \| `Ref`<`RouteLocationNormalizedLoaded`\> |
+
+#### Returns
+
+`void`

--- a/packages/docs/ja/api/interfaces/pinia.PiniaCustomStateProperties.md
+++ b/packages/docs/ja/api/interfaces/pinia.PiniaCustomStateProperties.md
@@ -1,0 +1,19 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / PiniaCustomStateProperties
+
+# Interface: PiniaCustomStateProperties<S\>
+
+[pinia](../modules/pinia.md).PiniaCustomStateProperties
+
+Properties that are added to every `store.$state` by `pinia.use()`.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) = [`StateTree`](../modules/pinia.md#statetree) |

--- a/packages/docs/ja/api/interfaces/pinia.PiniaPlugin.md
+++ b/packages/docs/ja/api/interfaces/pinia.PiniaPlugin.md
@@ -1,0 +1,30 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / PiniaPlugin
+
+# Interface: PiniaPlugin
+
+[pinia](../modules/pinia.md).PiniaPlugin
+
+## Callable
+
+### PiniaPlugin
+
+▸ **PiniaPlugin**(`context`): `void` \| `Partial`<[`PiniaCustomProperties`](pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\> & [`PiniaCustomStateProperties`](pinia.PiniaCustomStateProperties.md)<[`StateTree`](../modules/pinia.md#statetree)\>\>
+
+Plugin to extend every store. Returns an object to extend the store or
+nothing.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `context` | [`PiniaPluginContext`](pinia.PiniaPluginContext.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\> | Context |
+
+#### Returns
+
+`void` \| `Partial`<[`PiniaCustomProperties`](pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](../modules/pinia.md#statetree), [`_GettersTree`](../modules/pinia.md#_getterstree)<[`StateTree`](../modules/pinia.md#statetree)\>, [`_ActionsTree`](../modules/pinia.md#_actionstree)\> & [`PiniaCustomStateProperties`](pinia.PiniaCustomStateProperties.md)<[`StateTree`](../modules/pinia.md#statetree)\>\>

--- a/packages/docs/ja/api/interfaces/pinia.PiniaPluginContext.md
+++ b/packages/docs/ja/api/interfaces/pinia.PiniaPluginContext.md
@@ -1,0 +1,54 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / PiniaPluginContext
+
+# Interface: PiniaPluginContext<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).PiniaPluginContext
+
+Context argument passed to Pinia plugins.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` = `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) = [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | [`_GettersTree`](../modules/pinia.md#_getterstree)<`S`\> |
+| `A` | [`_ActionsTree`](../modules/pinia.md#_actionstree) |
+
+## Properties
+
+### app
+
+• **app**: `App`<`any`\>
+
+Current app created with `Vue.createApp()`.
+
+___
+
+### options
+
+• **options**: [`DefineStoreOptionsInPlugin`](pinia.DefineStoreOptionsInPlugin.md)<`Id`, `S`, `G`, `A`\>
+
+Initial options defining the store when calling `defineStore()`.
+
+___
+
+### pinia
+
+• **pinia**: [`Pinia`](pinia.Pinia.md)
+
+pinia instance.
+
+___
+
+### store
+
+• **store**: [`Store`](../modules/pinia.md#store)<`Id`, `S`, `G`, `A`\>
+
+Current store being extended.

--- a/packages/docs/ja/api/interfaces/pinia.StoreDefinition.md
+++ b/packages/docs/ja/api/interfaces/pinia.StoreDefinition.md
@@ -1,0 +1,47 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / StoreDefinition
+
+# Interface: StoreDefinition<Id, S, G, A\>
+
+[pinia](../modules/pinia.md).StoreDefinition
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` = `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) = [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | [`_GettersTree`](../modules/pinia.md#_getterstree)<`S`\> |
+| `A` | [`_ActionsTree`](../modules/pinia.md#_actionstree) |
+
+## Callable
+
+### StoreDefinition
+
+▸ **StoreDefinition**(`pinia?`, `hot?`): [`Store`](../modules/pinia.md#store)<`Id`, `S`, `G`, `A`\>
+
+Returns a store, creates it if necessary.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `pinia?` | ``null`` \| [`Pinia`](pinia.Pinia.md) | Pinia instance to retrieve the store |
+| `hot?` | [`StoreGeneric`](../modules/pinia.md#storegeneric) | dev only hot module replacement |
+
+#### Returns
+
+[`Store`](../modules/pinia.md#store)<`Id`, `S`, `G`, `A`\>
+
+## Properties
+
+### $id
+
+• **$id**: `Id`
+
+Id of the store. Used by map helpers.

--- a/packages/docs/ja/api/interfaces/pinia.StoreProperties.md
+++ b/packages/docs/ja/api/interfaces/pinia.StoreProperties.md
@@ -1,0 +1,43 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / StoreProperties
+
+# Interface: StoreProperties<Id\>
+
+[pinia](../modules/pinia.md).StoreProperties
+
+Properties of a store.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+
+## Hierarchy
+
+- **`StoreProperties`**
+
+  ↳ [`_StoreWithState`](pinia._StoreWithState.md)
+
+## Properties
+
+### $id
+
+• **$id**: `Id`
+
+Unique identifier of the store
+
+___
+
+### \_customProperties
+
+• **\_customProperties**: `Set`<`string`\>
+
+Used by devtools plugin to retrieve properties added with plugins. Removed
+in production. Can be used by the user to add property keys of the store
+that should be displayed in devtools.

--- a/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
+++ b/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
@@ -1,0 +1,59 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationDirect
+
+# Interface: SubscriptionCallbackMutationDirect
+
+[pinia](../modules/pinia.md).SubscriptionCallbackMutationDirect
+
+Context passed to a subscription callback when directly mutating the state of
+a store with `store.someState = newValue` or `store.$state.someState =
+newValue`.
+
+## Hierarchy
+
+- [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
+
+  ↳ **`SubscriptionCallbackMutationDirect`**
+
+## Properties
+
+### events
+
+• **events**: `DebuggerEvent`
+
+🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
+devtools and plugins **during development only**.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
+
+___
+
+### storeId
+
+• **storeId**: `string`
+
+`id` of the store doing the mutation.
+
+#### Inherited from
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
+
+___
+
+### type
+
+• **type**: [`direct`](../enums/pinia.MutationType.md#direct)
+
+Type of the mutation.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
+++ b/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
@@ -1,0 +1,58 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationPatchFunction
+
+# Interface: SubscriptionCallbackMutationPatchFunction
+
+[pinia](../modules/pinia.md).SubscriptionCallbackMutationPatchFunction
+
+Context passed to a subscription callback when `store.$patch()` is called
+with a function.
+
+## Hierarchy
+
+- [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
+
+  ↳ **`SubscriptionCallbackMutationPatchFunction`**
+
+## Properties
+
+### events
+
+• **events**: `DebuggerEvent`[]
+
+🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
+devtools and plugins **during development only**.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
+
+___
+
+### storeId
+
+• **storeId**: `string`
+
+`id` of the store doing the mutation.
+
+#### Inherited from
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
+
+___
+
+### type
+
+• **type**: [`patchFunction`](../enums/pinia.MutationType.md#patchfunction)
+
+Type of the mutation.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
+++ b/packages/docs/ja/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
@@ -1,0 +1,72 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationPatchObject
+
+# Interface: SubscriptionCallbackMutationPatchObject<S\>
+
+[pinia](../modules/pinia.md).SubscriptionCallbackMutationPatchObject
+
+Context passed to a subscription callback when `store.$patch()` is called
+with an object.
+
+## Type parameters
+
+| Name |
+| :------ |
+| `S` |
+
+## Hierarchy
+
+- [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
+
+  ↳ **`SubscriptionCallbackMutationPatchObject`**
+
+## Properties
+
+### events
+
+• **events**: `DebuggerEvent`[]
+
+🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
+devtools and plugins **during development only**.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
+
+___
+
+### payload
+
+• **payload**: [`_DeepPartial`](../modules/pinia.md#_deeppartial)<`S`\>
+
+Object passed to `store.$patch()`.
+
+___
+
+### storeId
+
+• **storeId**: `string`
+
+`id` of the store doing the mutation.
+
+#### Inherited from
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
+
+___
+
+### type
+
+• **type**: [`patchObject`](../enums/pinia.MutationType.md#patchobject)
+
+Type of the mutation.
+
+#### Overrides
+
+[_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/packages/docs/ja/api/interfaces/pinia._StoreOnActionListenerContext.md
+++ b/packages/docs/ja/api/interfaces/pinia._StoreOnActionListenerContext.md
@@ -1,0 +1,93 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_StoreOnActionListenerContext
+
+# Interface: \_StoreOnActionListenerContext<Store, ActionName, A\>
+
+[pinia](../modules/pinia.md)._StoreOnActionListenerContext
+
+Actual type for [StoreOnActionListenerContext](../modules/pinia.md#storeonactionlistenercontext). Exists for refactoring
+purposes. For internal use only.
+For internal use **only**
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Store` | `Store` |
+| `ActionName` | extends `string` |
+| `A` | `A` |
+
+## Properties
+
+### after
+
+• **after**: (`callback`: `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void`) => `void`
+
+#### Type declaration
+
+▸ (`callback`): `void`
+
+Sets up a hook once the action is finished. It receives the return value
+of the action, if it's a Promise, it will be unwrapped.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void` |
+
+##### Returns
+
+`void`
+
+___
+
+### args
+
+• **args**: `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? `Parameters`<`A`[`ActionName`]\> : `unknown`[]
+
+Parameters passed to the action
+
+___
+
+### name
+
+• **name**: `ActionName`
+
+Name of the action
+
+___
+
+### onError
+
+• **onError**: (`callback`: (`error`: `unknown`) => `void`) => `void`
+
+#### Type declaration
+
+▸ (`callback`): `void`
+
+Sets up a hook if the action fails. Return `false` to catch the error and
+stop it from propagating.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | (`error`: `unknown`) => `void` |
+
+##### Returns
+
+`void`
+
+___
+
+### store
+
+• **store**: `Store`
+
+Store that is invoking the action

--- a/packages/docs/ja/api/interfaces/pinia._StoreWithState.md
+++ b/packages/docs/ja/api/interfaces/pinia._StoreWithState.md
@@ -1,0 +1,253 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_StoreWithState
+
+# Interface: \_StoreWithState<Id, S, G, A\>
+
+[pinia](../modules/pinia.md)._StoreWithState
+
+Base store with state and functions. Should not be used directly.
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+## Hierarchy
+
+- [`StoreProperties`](pinia.StoreProperties.md)<`Id`\>
+
+  ↳ **`_StoreWithState`**
+
+## Properties
+
+### $id
+
+• **$id**: `Id`
+
+Unique identifier of the store
+
+#### Inherited from
+
+[StoreProperties](pinia.StoreProperties.md).[$id](pinia.StoreProperties.md#$id)
+
+___
+
+### $state
+
+• **$state**: `UnwrapRef`<`S`\> & [`PiniaCustomStateProperties`](pinia.PiniaCustomStateProperties.md)<`S`\>
+
+State of the Store. Setting it will replace the whole state.
+
+___
+
+### \_customProperties
+
+• **\_customProperties**: `Set`<`string`\>
+
+Used by devtools plugin to retrieve properties added with plugins. Removed
+in production. Can be used by the user to add property keys of the store
+that should be displayed in devtools.
+
+#### Inherited from
+
+[StoreProperties](pinia.StoreProperties.md).[_customProperties](pinia.StoreProperties.md#_customproperties)
+
+## Methods
+
+### $dispose
+
+▸ **$dispose**(): `void`
+
+Stops the associated effect scope of the store and remove it from the store
+registry. Plugins can override this method to cleanup any added effects.
+e.g. devtools plugin stops displaying disposed stores from devtools.
+
+#### Returns
+
+`void`
+
+___
+
+### $onAction
+
+▸ **$onAction**(`callback`, `detached?`): () => `void`
+
+Setups a callback to be called every time an action is about to get
+invoked. The callback receives an object with all the relevant information
+of the invoked action:
+- `store`: the store it is invoked on
+- `name`: The name of the action
+- `args`: The parameters passed to the action
+
+On top of these, it receives two functions that allow setting up a callback
+once the action finishes or when it fails.
+
+It also returns a function to remove the callback. Note than when calling
+`store.$onAction()` inside of a component, it will be automatically cleaned
+up when the component gets unmounted unless `detached` is set to true.
+
+**`Example`**
+
+```js
+store.$onAction(({ after, onError }) => {
+ // Here you could share variables between all of the hooks as well as
+ // setting up watchers and clean them up
+ after((resolvedValue) => {
+   // can be used to cleanup side effects
+.  // `resolvedValue` is the value returned by the action, if it's a
+.  // Promise, it will be the resolved value instead of the Promise
+ })
+ onError((error) => {
+   // can be used to pass up errors
+ })
+})
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `callback` | [`StoreOnActionListener`](../modules/pinia.md#storeonactionlistener)<`Id`, `S`, `G`, `A`\> | callback called before every action |
+| `detached?` | `boolean` | detach the subscription from the context this is called from |
+
+#### Returns
+
+`fn`
+
+function that removes the watcher
+
+▸ (): `void`
+
+Setups a callback to be called every time an action is about to get
+invoked. The callback receives an object with all the relevant information
+of the invoked action:
+- `store`: the store it is invoked on
+- `name`: The name of the action
+- `args`: The parameters passed to the action
+
+On top of these, it receives two functions that allow setting up a callback
+once the action finishes or when it fails.
+
+It also returns a function to remove the callback. Note than when calling
+`store.$onAction()` inside of a component, it will be automatically cleaned
+up when the component gets unmounted unless `detached` is set to true.
+
+**`Example`**
+
+```js
+store.$onAction(({ after, onError }) => {
+ // Here you could share variables between all of the hooks as well as
+ // setting up watchers and clean them up
+ after((resolvedValue) => {
+   // can be used to cleanup side effects
+.  // `resolvedValue` is the value returned by the action, if it's a
+.  // Promise, it will be the resolved value instead of the Promise
+ })
+ onError((error) => {
+   // can be used to pass up errors
+ })
+})
+```
+
+##### Returns
+
+`void`
+
+function that removes the watcher
+
+___
+
+### $patch
+
+▸ **$patch**(`partialState`): `void`
+
+Applies a state patch to current state. Allows passing nested values
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `partialState` | [`_DeepPartial`](../modules/pinia.md#_deeppartial)<`UnwrapRef`<`S`\>\> | patch to apply to the state |
+
+#### Returns
+
+`void`
+
+▸ **$patch**<`F`\>(`stateMutator`): `void`
+
+Group multiple changes into one function. Useful when mutating objects like
+Sets or arrays and applying an object patch isn't practical, e.g. appending
+to an array. The function passed to `$patch()` **must be synchronous**.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `F` | extends (`state`: `UnwrapRef`<`S`\>) => `any` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `stateMutator` | `ReturnType`<`F`\> extends `Promise`<`any`\> ? `never` : `F` | function that mutates `state`, cannot be async |
+
+#### Returns
+
+`void`
+
+___
+
+### $reset
+
+▸ **$reset**(): `void`
+
+Resets the store to its initial state by building a new state object.
+TODO: make this options only
+
+#### Returns
+
+`void`
+
+___
+
+### $subscribe
+
+▸ **$subscribe**(`callback`, `options?`): () => `void`
+
+Setups a callback to be called whenever the state changes. It also returns a function to remove the callback. Note
+that when calling `store.$subscribe()` inside of a component, it will be automatically cleaned up when the
+component gets unmounted unless `detached` is set to true.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `callback` | [`SubscriptionCallback`](../modules/pinia.md#subscriptioncallback)<`S`\> | callback passed to the watcher |
+| `options?` | { `detached?`: `boolean`  } & `WatchOptions`<`boolean`\> | `watch` options + `detached` to detach the subscription from the context (usually a component) this is called from. Note that the `flush` option does not affect calls to `store.$patch()`. |
+
+#### Returns
+
+`fn`
+
+function that removes the watcher
+
+▸ (): `void`
+
+Setups a callback to be called whenever the state changes. It also returns a function to remove the callback. Note
+that when calling `store.$subscribe()` inside of a component, it will be automatically cleaned up when the
+component gets unmounted unless `detached` is set to true.
+
+##### Returns
+
+`void`
+
+function that removes the watcher

--- a/packages/docs/ja/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
+++ b/packages/docs/ja/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
@@ -1,0 +1,49 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_SubscriptionCallbackMutationBase
+
+# Interface: \_SubscriptionCallbackMutationBase
+
+[pinia](../modules/pinia.md)._SubscriptionCallbackMutationBase
+
+Base type for the context passed to a subscription callback. Internal type.
+
+## Hierarchy
+
+- **`_SubscriptionCallbackMutationBase`**
+
+  ↳ [`SubscriptionCallbackMutationDirect`](pinia.SubscriptionCallbackMutationDirect.md)
+
+  ↳ [`SubscriptionCallbackMutationPatchFunction`](pinia.SubscriptionCallbackMutationPatchFunction.md)
+
+  ↳ [`SubscriptionCallbackMutationPatchObject`](pinia.SubscriptionCallbackMutationPatchObject.md)
+
+## Properties
+
+### events
+
+• `Optional` **events**: `DebuggerEvent` \| `DebuggerEvent`[]
+
+🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
+devtools and plugins **during development only**.
+
+___
+
+### storeId
+
+• **storeId**: `string`
+
+`id` of the store doing the mutation.
+
+___
+
+### type
+
+• **type**: [`MutationType`](../enums/pinia.MutationType.md)
+
+Type of the mutation.

--- a/packages/docs/ja/api/interfaces/pinia_nuxt.ModuleOptions.md
+++ b/packages/docs/ja/api/interfaces/pinia_nuxt.ModuleOptions.md
@@ -1,0 +1,43 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [@pinia/nuxt](../modules/pinia_nuxt.md) / ModuleOptions
+
+# Interface: ModuleOptions
+
+[@pinia/nuxt](../modules/pinia_nuxt.md).ModuleOptions
+
+## Properties
+
+### autoImports
+
+• `Optional` **autoImports**: (`string` \| [`string`, `string`])[]
+
+Array of auto imports to be added to the nuxt.config.js file.
+
+**`Example`**
+
+```js
+autoImports: [
+ // automatically import `defineStore`
+ 'defineStore',
+ // automatically import `defineStore` as `definePiniaStore`
+ ['defineStore', 'definePiniaStore',
+]
+```
+
+___
+
+### disableVuex
+
+• `Optional` **disableVuex**: `boolean`
+
+Pinia disables Vuex by default, set this option to `false` to avoid it and
+use Pinia alongside Vuex (Nuxt 2 only)
+
+**`Default`**
+
+`true`

--- a/packages/docs/ja/api/interfaces/pinia_testing.TestingOptions.md
+++ b/packages/docs/ja/api/interfaces/pinia_testing.TestingOptions.md
@@ -1,0 +1,97 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingOptions
+
+# Interface: TestingOptions
+
+[@pinia/testing](../modules/pinia_testing.md).TestingOptions
+
+## Properties
+
+### createSpy
+
+• `Optional` **createSpy**: (`fn?`: (...`args`: `any`[]) => `any`) => (...`args`: `any`[]) => `any`
+
+#### Type declaration
+
+▸ (`fn?`): (...`args`: `any`[]) => `any`
+
+Function used to create a spy for actions and `$patch()`. Pre-configured
+with `jest.fn()` in jest projects or `vi.fn()` in vitest projects.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `fn?` | (...`args`: `any`[]) => `any` |
+
+##### Returns
+
+`fn`
+
+▸ (...`args`): `any`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`[] |
+
+##### Returns
+
+`any`
+
+___
+
+### fakeApp
+
+• `Optional` **fakeApp**: `boolean`
+
+Creates an empty App and calls `app.use(pinia)` with the created testing
+pinia. This is allows you to use plugins while unit testing stores as
+plugins **will wait for pinia to be installed in order to be executed**.
+Defaults to false.
+
+___
+
+### initialState
+
+• `Optional` **initialState**: [`StateTree`](../modules/pinia.md#statetree)
+
+Allows defining a partial initial state of all your stores. This state gets applied after a store is created,
+allowing you to only set a few properties that are required in your test.
+
+___
+
+### plugins
+
+• `Optional` **plugins**: [`PiniaPlugin`](pinia.PiniaPlugin.md)[]
+
+Plugins to be installed before the testing plugin. Add any plugins used in
+your application that will be used while testing.
+
+___
+
+### stubActions
+
+• `Optional` **stubActions**: `boolean`
+
+When set to false, actions are only spied, they still get executed. When
+set to true, actions will be replaced with spies, resulting in their code
+not being executed. Defaults to true. NOTE: when providing `createSpy()`,
+it will **only** make the `fn` argument `undefined`. You still have to
+handle this in `createSpy()`.
+
+___
+
+### stubPatch
+
+• `Optional` **stubPatch**: `boolean`
+
+When set to true, calls to `$patch()` won't change the state. Defaults to
+false. NOTE: when providing `createSpy()`, it will **only** make the `fn`
+argument `undefined`. You still have to handle this in `createSpy()`.

--- a/packages/docs/ja/api/interfaces/pinia_testing.TestingPinia.md
+++ b/packages/docs/ja/api/interfaces/pinia_testing.TestingPinia.md
@@ -1,0 +1,86 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingPinia
+
+# Interface: TestingPinia
+
+[@pinia/testing](../modules/pinia_testing.md).TestingPinia
+
+Pinia instance specifically designed for testing. Extends a regular
+`Pinia` instance with test specific properties.
+
+## Hierarchy
+
+- [`Pinia`](pinia.Pinia.md)
+
+  ↳ **`TestingPinia`**
+
+## Properties
+
+### app
+
+• **app**: `App`<`any`\>
+
+App used by Pinia
+
+___
+
+### install
+
+• **install**: (`app`: `App`<`any`\>) => `void`
+
+#### Type declaration
+
+▸ (`app`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `app` | `App`<`any`\> |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[Pinia](pinia.Pinia.md).[install](pinia.Pinia.md#install)
+
+___
+
+### state
+
+• **state**: `Ref`<`Record`<`string`, [`StateTree`](../modules/pinia.md#statetree)\>\>
+
+root state
+
+#### Inherited from
+
+[Pinia](pinia.Pinia.md).[state](pinia.Pinia.md#state)
+
+## Methods
+
+### use
+
+▸ **use**(`plugin`): [`Pinia`](pinia.Pinia.md)
+
+Adds a store plugin to extend every store
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `plugin` | [`PiniaPlugin`](pinia.PiniaPlugin.md) | store plugin to add |
+
+#### Returns
+
+[`Pinia`](pinia.Pinia.md)
+
+#### Inherited from
+
+[Pinia](pinia.Pinia.md).[use](pinia.Pinia.md#use)

--- a/packages/docs/ja/api/modules/pinia.md
+++ b/packages/docs/ja/api/modules/pinia.md
@@ -1,0 +1,1162 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / pinia
+
+# Module: pinia
+
+## Enumerations
+
+- [MutationType](../enums/pinia.MutationType.md)
+
+## Interfaces
+
+- [DefineSetupStoreOptions](../interfaces/pinia.DefineSetupStoreOptions.md)
+- [DefineStoreOptions](../interfaces/pinia.DefineStoreOptions.md)
+- [DefineStoreOptionsBase](../interfaces/pinia.DefineStoreOptionsBase.md)
+- [DefineStoreOptionsInPlugin](../interfaces/pinia.DefineStoreOptionsInPlugin.md)
+- [MapStoresCustomization](../interfaces/pinia.MapStoresCustomization.md)
+- [Pinia](../interfaces/pinia.Pinia.md)
+- [PiniaCustomProperties](../interfaces/pinia.PiniaCustomProperties.md)
+- [PiniaCustomStateProperties](../interfaces/pinia.PiniaCustomStateProperties.md)
+- [PiniaPlugin](../interfaces/pinia.PiniaPlugin.md)
+- [PiniaPluginContext](../interfaces/pinia.PiniaPluginContext.md)
+- [StoreDefinition](../interfaces/pinia.StoreDefinition.md)
+- [StoreProperties](../interfaces/pinia.StoreProperties.md)
+- [SubscriptionCallbackMutationDirect](../interfaces/pinia.SubscriptionCallbackMutationDirect.md)
+- [SubscriptionCallbackMutationPatchFunction](../interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md)
+- [SubscriptionCallbackMutationPatchObject](../interfaces/pinia.SubscriptionCallbackMutationPatchObject.md)
+- [\_StoreOnActionListenerContext](../interfaces/pinia._StoreOnActionListenerContext.md)
+- [\_StoreWithState](../interfaces/pinia._StoreWithState.md)
+- [\_SubscriptionCallbackMutationBase](../interfaces/pinia._SubscriptionCallbackMutationBase.md)
+
+## Type Aliases
+
+### PiniaStorePlugin
+
+Ƭ **PiniaStorePlugin**: [`PiniaPlugin`](../interfaces/pinia.PiniaPlugin.md)
+
+Plugin to extend every store.
+
+**`Deprecated`**
+
+use PiniaPlugin instead
+
+___
+
+### StateTree
+
+Ƭ **StateTree**: `Record`<`string` \| `number` \| `symbol`, `any`\>
+
+Generic state of a Store
+
+___
+
+### Store
+
+Ƭ **Store**<`Id`, `S`, `G`, `A`\>: [`_StoreWithState`](../interfaces/pinia._StoreWithState.md)<`Id`, `S`, `G`, `A`\> & `UnwrapRef`<`S`\> & [`_StoreWithGetters`](pinia.md#_storewithgetters)<`G`\> & [`_ActionsTree`](pinia.md#_actionstree) extends `A` ? {} : `A` & [`PiniaCustomProperties`](../interfaces/pinia.PiniaCustomProperties.md)<`Id`, `S`, `G`, `A`\> & [`PiniaCustomStateProperties`](../interfaces/pinia.PiniaCustomStateProperties.md)<`S`\>
+
+Store type to build a store.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` = `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) = {} |
+| `G` | {} |
+| `A` | {} |
+
+___
+
+### StoreActions
+
+Ƭ **StoreActions**<`SS`\>: `SS` extends [`Store`](pinia.md#store)<`string`, [`StateTree`](pinia.md#statetree), [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, infer A\> ? `A` : [`_ExtractActionsFromSetupStore`](pinia.md#_extractactionsfromsetupstore)<`SS`\>
+
+Extract the actions of a store type. Works with both a Setup Store or an
+Options Store.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### StoreGeneric
+
+Ƭ **StoreGeneric**: [`Store`](pinia.md#store)<`string`, [`StateTree`](pinia.md#statetree), [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, [`_ActionsTree`](pinia.md#_actionstree)\>
+
+Generic and type-unsafe version of Store. Doesn't fail on access with
+strings, making it much easier to write generic functions that do not care
+about the kind of store that is passed.
+
+___
+
+### StoreGetters
+
+Ƭ **StoreGetters**<`SS`\>: `SS` extends [`Store`](pinia.md#store)<`string`, [`StateTree`](pinia.md#statetree), infer G, [`_ActionsTree`](pinia.md#_actionstree)\> ? [`_StoreWithGetters`](pinia.md#_storewithgetters)<`G`\> : [`_ExtractGettersFromSetupStore`](pinia.md#_extractgettersfromsetupstore)<`SS`\>
+
+Extract the getters of a store type. Works with both a Setup Store or an
+Options Store.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### StoreOnActionListener
+
+Ƭ **StoreOnActionListener**<`Id`, `S`, `G`, `A`\>: (`context`: [`StoreOnActionListenerContext`](pinia.md#storeonactionlistenercontext)<`Id`, `S`, `G`, {} extends `A` ? [`_ActionsTree`](pinia.md#_actionstree) : `A`\>) => `void`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+#### Type declaration
+
+▸ (`context`): `void`
+
+Argument of `store.$onAction()`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `context` | [`StoreOnActionListenerContext`](pinia.md#storeonactionlistenercontext)<`Id`, `S`, `G`, {} extends `A` ? [`_ActionsTree`](pinia.md#_actionstree) : `A`\> |
+
+##### Returns
+
+`void`
+
+___
+
+### StoreOnActionListenerContext
+
+Ƭ **StoreOnActionListenerContext**<`Id`, `S`, `G`, `A`\>: [`_ActionsTree`](pinia.md#_actionstree) extends `A` ? [`_StoreOnActionListenerContext`](../interfaces/pinia._StoreOnActionListenerContext.md)<[`StoreGeneric`](pinia.md#storegeneric), `string`, [`_ActionsTree`](pinia.md#_actionstree)\> : { [Name in keyof A]: Name extends string ? \_StoreOnActionListenerContext<Store<Id, S, G, A\>, Name, A\> : never }[keyof `A`]
+
+Context object passed to callbacks of `store.$onAction(context => {})`
+TODO: should have only the Id, the Store and Actions to generate the proper object
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | `G` |
+| `A` | `A` |
+
+___
+
+### StoreState
+
+Ƭ **StoreState**<`SS`\>: `SS` extends [`Store`](pinia.md#store)<`string`, infer S, [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, [`_ActionsTree`](pinia.md#_actionstree)\> ? `UnwrapRef`<`S`\> : [`_ExtractStateFromSetupStore`](pinia.md#_extractstatefromsetupstore)<`SS`\>
+
+Extract the state of a store type. Works with both a Setup Store or an
+Options Store. Note this unwraps refs.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### SubscriptionCallback
+
+Ƭ **SubscriptionCallback**<`S`\>: (`mutation`: [`SubscriptionCallbackMutation`](pinia.md#subscriptioncallbackmutation)<`S`\>, `state`: `UnwrapRef`<`S`\>) => `void`
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `S` |
+
+#### Type declaration
+
+▸ (`mutation`, `state`): `void`
+
+Callback of a subscription
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `mutation` | [`SubscriptionCallbackMutation`](pinia.md#subscriptioncallbackmutation)<`S`\> |
+| `state` | `UnwrapRef`<`S`\> |
+
+##### Returns
+
+`void`
+
+___
+
+### SubscriptionCallbackMutation
+
+Ƭ **SubscriptionCallbackMutation**<`S`\>: [`SubscriptionCallbackMutationDirect`](../interfaces/pinia.SubscriptionCallbackMutationDirect.md) \| [`SubscriptionCallbackMutationPatchObject`](../interfaces/pinia.SubscriptionCallbackMutationPatchObject.md)<`S`\> \| [`SubscriptionCallbackMutationPatchFunction`](../interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md)
+
+Context object passed to a subscription callback.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `S` |
+
+___
+
+### \_ActionsTree
+
+Ƭ **\_ActionsTree**: `Record`<`string`, [`_Method`](pinia.md#_method)\>
+
+Type of an object of Actions. For internal usage only.
+For internal use **only**
+
+___
+
+### \_Awaited
+
+Ƭ **\_Awaited**<`T`\>: `T` extends ``null`` \| `undefined` ? `T` : `T` extends `object` & { `then`: (`onfulfilled`: `F`) => `any`  } ? `F` extends (`value`: infer V, ...`args`: `any`) => `any` ? [`_Awaited`](pinia.md#_awaited)<`V`\> : `never` : `T`
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+___
+
+### \_DeepPartial
+
+Ƭ **\_DeepPartial**<`T`\>: { [K in keyof T]?: \_DeepPartial<T[K]\> }
+
+Recursive `Partial<T>`. Used by [['$patch']](pinia.md#store).
+
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+___
+
+### \_ExtractActionsFromSetupStore
+
+Ƭ **\_ExtractActionsFromSetupStore**<`SS`\>: `SS` extends `undefined` \| `void` ? {} : [`_ExtractActionsFromSetupStore_Keys`](pinia.md#_extractactionsfromsetupstore_keys)<`SS`\> extends keyof `SS` ? `Pick`<`SS`, [`_ExtractActionsFromSetupStore_Keys`](pinia.md#_extractactionsfromsetupstore_keys)<`SS`\>\> : `never`
+
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_ExtractActionsFromSetupStore\_Keys
+
+Ƭ **\_ExtractActionsFromSetupStore\_Keys**<`SS`\>: keyof { [K in keyof SS as SS[K] extends \_Method ? K : never]: any }
+
+Type that enables refactoring through IDE.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_ExtractGettersFromSetupStore
+
+Ƭ **\_ExtractGettersFromSetupStore**<`SS`\>: `SS` extends `undefined` \| `void` ? {} : [`_ExtractGettersFromSetupStore_Keys`](pinia.md#_extractgettersfromsetupstore_keys)<`SS`\> extends keyof `SS` ? `Pick`<`SS`, [`_ExtractGettersFromSetupStore_Keys`](pinia.md#_extractgettersfromsetupstore_keys)<`SS`\>\> : `never`
+
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_ExtractGettersFromSetupStore\_Keys
+
+Ƭ **\_ExtractGettersFromSetupStore\_Keys**<`SS`\>: keyof { [K in keyof SS as SS[K] extends ComputedRef ? K : never]: any }
+
+Type that enables refactoring through IDE.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_ExtractStateFromSetupStore
+
+Ƭ **\_ExtractStateFromSetupStore**<`SS`\>: `SS` extends `undefined` \| `void` ? {} : [`_ExtractStateFromSetupStore_Keys`](pinia.md#_extractstatefromsetupstore_keys)<`SS`\> extends keyof `SS` ? [`_UnwrapAll`](pinia.md#_unwrapall)<`Pick`<`SS`, [`_ExtractStateFromSetupStore_Keys`](pinia.md#_extractstatefromsetupstore_keys)<`SS`\>\>\> : `never`
+
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_ExtractStateFromSetupStore\_Keys
+
+Ƭ **\_ExtractStateFromSetupStore\_Keys**<`SS`\>: keyof { [K in keyof SS as SS[K] extends \_Method \| ComputedRef ? never : K]: any }
+
+Type that enables refactoring through IDE.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+___
+
+### \_GettersTree
+
+Ƭ **\_GettersTree**<`S`\>: `Record`<`string`, (`state`: `UnwrapRef`<`S`\> & `UnwrapRef`<[`PiniaCustomStateProperties`](../interfaces/pinia.PiniaCustomStateProperties.md)<`S`\>\>) => `any` \| () => `any`\>
+
+Type of an object of Getters that infers the argument. For internal usage only.
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+
+___
+
+### \_MapActionsObjectReturn
+
+Ƭ **\_MapActionsObjectReturn**<`A`, `T`\>: { [key in keyof T]: A[T[key]] }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `A` | `A` |
+| `T` | extends `Record`<`string`, keyof `A`\> |
+
+___
+
+### \_MapActionsReturn
+
+Ƭ **\_MapActionsReturn**<`A`\>: { [key in keyof A]: A[key] }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `A` |
+
+___
+
+### \_MapStateObjectReturn
+
+Ƭ **\_MapStateObjectReturn**<`Id`, `S`, `G`, `A`, `T`\>: { [key in keyof T]: Function }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `T` | extends `Record`<`string`, keyof `S` \| keyof `G` \| (`store`: [`Store`](pinia.md#store)<`Id`, `S`, `G`, `A`\>) => `any`\> = {} |
+
+___
+
+### \_MapStateReturn
+
+Ƭ **\_MapStateReturn**<`S`, `G`, `Keys`\>: { [key in Keys]: Function }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `Keys` | extends keyof `S` \| keyof `G` = keyof `S` \| keyof `G` |
+
+___
+
+### \_MapWritableStateObjectReturn
+
+Ƭ **\_MapWritableStateObjectReturn**<`S`, `T`\>: { [key in keyof T]: Object }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `T` | extends `Record`<`string`, keyof `S`\> |
+
+___
+
+### \_MapWritableStateReturn
+
+Ƭ **\_MapWritableStateReturn**<`S`\>: { [key in keyof S]: Object }
+
+For internal use **only**
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+
+___
+
+### \_Method
+
+Ƭ **\_Method**: (...`args`: `any`[]) => `any`
+
+#### Type declaration
+
+▸ (...`args`): `any`
+
+Generic type for a function that can infer arguments and return type
+
+For internal use **only**
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | `any`[] |
+
+##### Returns
+
+`any`
+
+___
+
+### \_Spread
+
+Ƭ **\_Spread**<`A`\>: `A` extends [infer L, ...(infer R)] ? [`_StoreObject`](pinia.md#_storeobject)<`L`\> & [`_Spread`](pinia.md#_spread)<`R`\> : `unknown`
+
+For internal use **only**.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `A` | extends readonly `any`[] |
+
+___
+
+### \_StoreObject
+
+Ƭ **\_StoreObject**<`S`\>: `S` extends [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<infer Ids, infer State, infer Getters, infer Actions\> ? { [Id in \`${Ids}${MapStoresCustomization extends Record<"suffix", infer Suffix extends string\> ? Suffix : "Store"}\`]: Function } : {}
+
+For internal use **only**.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `S` |
+
+___
+
+### \_StoreWithActions
+
+Ƭ **\_StoreWithActions**<`A`\>: { [k in keyof A]: A[k] extends Function ? Function : never }
+
+Store augmented for actions. For internal usage only.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `A` |
+
+___
+
+### \_StoreWithGetters
+
+Ƭ **\_StoreWithGetters**<`G`\>: { readonly [k in keyof G]: G[k] extends Function ? R : UnwrapRef<G[k]\> }
+
+Store augmented with getters. For internal usage only.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `G` |
+
+___
+
+### \_UnwrapAll
+
+Ƭ **\_UnwrapAll**<`SS`\>: { [K in keyof SS]: UnwrapRef<SS[K]\> }
+
+Type that enables refactoring through IDE.
+For internal use **only**
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SS` |
+
+## Variables
+
+### PiniaVuePlugin
+
+• `Const` **PiniaVuePlugin**: `Plugin`
+
+Vue 2 Plugin that must be installed for pinia to work. Note **you don't need
+this plugin if you are using Nuxt.js**. Use the `buildModule` instead:
+https://pinia.vuejs.org/ssr/nuxt.html.
+
+**`Example`**
+
+```js
+import Vue from 'vue'
+import { PiniaVuePlugin, createPinia } from 'pinia'
+
+Vue.use(PiniaVuePlugin)
+const pinia = createPinia()
+
+new Vue({
+  el: '#app',
+  // ...
+  pinia,
+})
+```
+
+**`Param`**
+
+`Vue` imported from 'vue'.
+
+## Functions
+
+### acceptHMRUpdate
+
+▸ **acceptHMRUpdate**(`initialUseStore`, `hot`): (`newModule`: `any`) => `any`
+
+Creates an _accept_ function to pass to `import.meta.hot` in Vite applications.
+
+**`Example`**
+
+```js
+const useUser = defineStore(...)
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useUser, import.meta.hot))
+}
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `initialUseStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`string`, [`StateTree`](pinia.md#statetree), [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, [`_ActionsTree`](pinia.md#_actionstree)\> | return of the defineStore to hot update |
+| `hot` | `any` | `import.meta.hot` |
+
+#### Returns
+
+`fn`
+
+▸ (`newModule`): `any`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newModule` | `any` |
+
+##### Returns
+
+`any`
+
+___
+
+### createPinia
+
+▸ **createPinia**(): [`Pinia`](../interfaces/pinia.Pinia.md)
+
+Creates a Pinia instance to be used by the application
+
+#### Returns
+
+[`Pinia`](../interfaces/pinia.Pinia.md)
+
+___
+
+### defineStore
+
+▸ **defineStore**<`Id`, `S`, `G`, `A`\>(`id`, `options`): [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\>
+
+Creates a `useStore` function that retrieves the store instance
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) = {} |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> = {} |
+| `A` | {} |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `Id` | id of the store (must be unique) |
+| `options` | `Omit`<[`DefineStoreOptions`](../interfaces/pinia.DefineStoreOptions.md)<`Id`, `S`, `G`, `A`\>, ``"id"``\> | options to define the store |
+
+#### Returns
+
+[`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\>
+
+▸ **defineStore**<`Id`, `S`, `G`, `A`\>(`options`): [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\>
+
+Creates a `useStore` function that retrieves the store instance
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) = {} |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> = {} |
+| `A` | {} |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | [`DefineStoreOptions`](../interfaces/pinia.DefineStoreOptions.md)<`Id`, `S`, `G`, `A`\> | options to define the store |
+
+#### Returns
+
+[`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\>
+
+▸ **defineStore**<`Id`, `SS`\>(`id`, `storeSetup`, `options?`): [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, [`_ExtractStateFromSetupStore`](pinia.md#_extractstatefromsetupstore)<`SS`\>, [`_ExtractGettersFromSetupStore`](pinia.md#_extractgettersfromsetupstore)<`SS`\>, [`_ExtractActionsFromSetupStore`](pinia.md#_extractactionsfromsetupstore)<`SS`\>\>
+
+Creates a `useStore` function that retrieves the store instance
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `SS` | `SS` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `Id` | id of the store (must be unique) |
+| `storeSetup` | () => `SS` | function that defines the store |
+| `options?` | [`DefineSetupStoreOptions`](../interfaces/pinia.DefineSetupStoreOptions.md)<`Id`, [`_ExtractStateFromSetupStore`](pinia.md#_extractstatefromsetupstore)<`SS`\>, [`_ExtractGettersFromSetupStore`](pinia.md#_extractgettersfromsetupstore)<`SS`\>, [`_ExtractActionsFromSetupStore`](pinia.md#_extractactionsfromsetupstore)<`SS`\>\> | extra options |
+
+#### Returns
+
+[`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, [`_ExtractStateFromSetupStore`](pinia.md#_extractstatefromsetupstore)<`SS`\>, [`_ExtractGettersFromSetupStore`](pinia.md#_extractgettersfromsetupstore)<`SS`\>, [`_ExtractActionsFromSetupStore`](pinia.md#_extractactionsfromsetupstore)<`SS`\>\>
+
+___
+
+### getActivePinia
+
+▸ **getActivePinia**(): `undefined` \| [`Pinia`](../interfaces/pinia.Pinia.md)
+
+Get the currently active pinia if there is any.
+
+#### Returns
+
+`undefined` \| [`Pinia`](../interfaces/pinia.Pinia.md)
+
+___
+
+### mapActions
+
+▸ **mapActions**<`Id`, `S`, `G`, `A`, `KeyMapper`\>(`useStore`, `keyMapper`): [`_MapActionsObjectReturn`](pinia.md#_mapactionsobjectreturn)<`A`, `KeyMapper`\>
+
+Allows directly using actions from your store without using the composition
+API (`setup()`) by generating an object to be spread in the `methods` field
+of a component. The values of the object are the actions while the keys are
+the names of the resulting methods.
+
+**`Example`**
+
+```js
+export default {
+  methods: {
+    // other methods properties
+    // useCounterStore has two actions named `increment` and `setCount`
+    ...mapActions(useCounterStore, { moar: 'increment', setIt: 'setCount' })
+  },
+
+  created() {
+    this.moar()
+    this.setIt(2)
+  }
+}
+```
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `KeyMapper` | extends `Record`<`string`, keyof `A`\> |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keyMapper` | `KeyMapper` | object to define new names for the actions |
+
+#### Returns
+
+[`_MapActionsObjectReturn`](pinia.md#_mapactionsobjectreturn)<`A`, `KeyMapper`\>
+
+▸ **mapActions**<`Id`, `S`, `G`, `A`\>(`useStore`, `keys`): [`_MapActionsReturn`](pinia.md#_mapactionsreturn)<`A`\>
+
+Allows directly using actions from your store without using the composition
+API (`setup()`) by generating an object to be spread in the `methods` field
+of a component.
+
+**`Example`**
+
+```js
+export default {
+  methods: {
+    // other methods properties
+    ...mapActions(useCounterStore, ['increment', 'setCount'])
+  },
+
+  created() {
+    this.increment()
+    this.setCount(2) // pass arguments as usual
+  }
+}
+```
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keys` | keyof `A`[] | array of action names to map |
+
+#### Returns
+
+[`_MapActionsReturn`](pinia.md#_mapactionsreturn)<`A`\>
+
+___
+
+### mapGetters
+
+▸ **mapGetters**<`Id`, `S`, `G`, `A`, `KeyMapper`\>(`useStore`, `keyMapper`): [`_MapStateObjectReturn`](pinia.md#_mapstateobjectreturn)<`Id`, `S`, `G`, `A`, `KeyMapper`\>
+
+Alias for `mapState()`. You should use `mapState()` instead.
+
+**`Deprecated`**
+
+use `mapState()` instead.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `KeyMapper` | extends `Record`<`string`, keyof `S` \| keyof `G` \| (`store`: [`Store`](pinia.md#store)<`Id`, `S`, `G`, `A`\>) => `any`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> |
+| `keyMapper` | `KeyMapper` |
+
+#### Returns
+
+[`_MapStateObjectReturn`](pinia.md#_mapstateobjectreturn)<`Id`, `S`, `G`, `A`, `KeyMapper`\>
+
+▸ **mapGetters**<`Id`, `S`, `G`, `A`, `Keys`\>(`useStore`, `keys`): [`_MapStateReturn`](pinia.md#_mapstatereturn)<`S`, `G`, `Keys`\>
+
+Alias for `mapState()`. You should use `mapState()` instead.
+
+**`Deprecated`**
+
+use `mapState()` instead.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `Keys` | extends `string` \| `number` \| `symbol` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> |
+| `keys` | readonly `Keys`[] |
+
+#### Returns
+
+[`_MapStateReturn`](pinia.md#_mapstatereturn)<`S`, `G`, `Keys`\>
+
+___
+
+### mapState
+
+▸ **mapState**<`Id`, `S`, `G`, `A`, `KeyMapper`\>(`useStore`, `keyMapper`): [`_MapStateObjectReturn`](pinia.md#_mapstateobjectreturn)<`Id`, `S`, `G`, `A`, `KeyMapper`\>
+
+Allows using state and getters from one store without using the composition
+API (`setup()`) by generating an object to be spread in the `computed` field
+of a component. The values of the object are the state properties/getters
+while the keys are the names of the resulting computed properties.
+Optionally, you can also pass a custom function that will receive the store
+as its first argument. Note that while it has access to the component
+instance via `this`, it won't be typed.
+
+**`Example`**
+
+```js
+export default {
+  computed: {
+    // other computed properties
+    // useCounterStore has a state property named `count` and a getter `double`
+    ...mapState(useCounterStore, {
+      n: 'count',
+      triple: store => store.n * 3,
+      // note we can't use an arrow function if we want to use `this`
+      custom(store) {
+        return this.someComponentValue + store.n
+      },
+      doubleN: 'double'
+    })
+  },
+
+  created() {
+    this.n // 2
+    this.doubleN // 4
+  }
+}
+```
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `KeyMapper` | extends `Record`<`string`, keyof `S` \| keyof `G` \| (`store`: [`Store`](pinia.md#store)<`Id`, `S`, `G`, `A`\>) => `any`\> |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keyMapper` | `KeyMapper` | object of state properties or getters |
+
+#### Returns
+
+[`_MapStateObjectReturn`](pinia.md#_mapstateobjectreturn)<`Id`, `S`, `G`, `A`, `KeyMapper`\>
+
+▸ **mapState**<`Id`, `S`, `G`, `A`, `Keys`\>(`useStore`, `keys`): [`_MapStateReturn`](pinia.md#_mapstatereturn)<`S`, `G`, `Keys`\>
+
+Allows using state and getters from one store without using the composition
+API (`setup()`) by generating an object to be spread in the `computed` field
+of a component.
+
+**`Example`**
+
+```js
+export default {
+  computed: {
+    // other computed properties
+    ...mapState(useCounterStore, ['count', 'double'])
+  },
+
+  created() {
+    this.count // 2
+    this.double // 4
+  }
+}
+```
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `Keys` | extends `string` \| `number` \| `symbol` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keys` | readonly `Keys`[] | array of state properties or getters |
+
+#### Returns
+
+[`_MapStateReturn`](pinia.md#_mapstatereturn)<`S`, `G`, `Keys`\>
+
+___
+
+### mapStores
+
+▸ **mapStores**<`Stores`\>(...`stores`): [`_Spread`](pinia.md#_spread)<`Stores`\>
+
+Allows using stores without the composition API (`setup()`) by generating an
+object to be spread in the `computed` field of a component. It accepts a list
+of store definitions.
+
+**`Example`**
+
+```js
+export default {
+  computed: {
+    // other computed properties
+    ...mapStores(useUserStore, useCartStore)
+  },
+
+  created() {
+    this.userStore // store with id "user"
+    this.cartStore // store with id "cart"
+  }
+}
+```
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Stores` | extends `any`[] |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `...stores` | [...Stores[]] | list of stores to map to an object |
+
+#### Returns
+
+[`_Spread`](pinia.md#_spread)<`Stores`\>
+
+___
+
+### mapWritableState
+
+▸ **mapWritableState**<`Id`, `S`, `G`, `A`, `KeyMapper`\>(`useStore`, `keyMapper`): [`_MapWritableStateObjectReturn`](pinia.md#_mapwritablestateobjectreturn)<`S`, `KeyMapper`\>
+
+Same as `mapState()` but creates computed setters as well so the state can be
+modified. Differently from `mapState()`, only `state` properties can be
+added.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+| `KeyMapper` | extends `Record`<`string`, keyof `S`\> |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keyMapper` | `KeyMapper` | object of state properties |
+
+#### Returns
+
+[`_MapWritableStateObjectReturn`](pinia.md#_mapwritablestateobjectreturn)<`S`, `KeyMapper`\>
+
+▸ **mapWritableState**<`Id`, `S`, `G`, `A`\>(`useStore`, `keys`): [`_MapWritableStateReturn`](pinia.md#_mapwritablestatereturn)<`S`\>
+
+Allows using state and getters from one store without using the composition
+API (`setup()`) by generating an object to be spread in the `computed` field
+of a component.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Id` | extends `string` |
+| `S` | extends [`StateTree`](pinia.md#statetree) |
+| `G` | extends [`_GettersTree`](pinia.md#_getterstree)<`S`\> |
+| `A` | `A` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `useStore` | [`StoreDefinition`](../interfaces/pinia.StoreDefinition.md)<`Id`, `S`, `G`, `A`\> | store to map from |
+| `keys` | keyof `S`[] | array of state properties |
+
+#### Returns
+
+[`_MapWritableStateReturn`](pinia.md#_mapwritablestatereturn)<`S`\>
+
+___
+
+### setActivePinia
+
+▸ **setActivePinia**(`pinia`): `undefined` \| [`Pinia`](../interfaces/pinia.Pinia.md)
+
+Sets or unsets the active pinia. Used in SSR and internally when calling
+actions and getters
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `pinia` | `undefined` \| [`Pinia`](../interfaces/pinia.Pinia.md) | Pinia instance |
+
+#### Returns
+
+`undefined` \| [`Pinia`](../interfaces/pinia.Pinia.md)
+
+___
+
+### setMapStoreSuffix
+
+▸ **setMapStoreSuffix**(`suffix`): `void`
+
+Changes the suffix added by `mapStores()`. Can be set to an empty string.
+Defaults to `"Store"`. Make sure to extend the MapStoresCustomization
+interface if you are using TypeScript.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `suffix` | `string` | new suffix |
+
+#### Returns
+
+`void`
+
+___
+
+### skipHydrate
+
+▸ **skipHydrate**<`T`\>(`obj`): `T`
+
+Tells Pinia to skip the hydration process of a given object. This is useful in setup stores (only) when you return a
+stateful object in the store but it isn't really state. e.g. returning a router instance in a setup store.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `any` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `obj` | `T` | target object |
+
+#### Returns
+
+`T`
+
+obj
+
+___
+
+### storeToRefs
+
+▸ **storeToRefs**<`SS`\>(`store`): `ToRefs`<[`StoreState`](pinia.md#storestate)<`SS`\> & [`StoreGetters`](pinia.md#storegetters)<`SS`\> & [`PiniaCustomStateProperties`](../interfaces/pinia.PiniaCustomStateProperties.md)<[`StoreState`](pinia.md#storestate)<`SS`\>\>\>
+
+Creates an object of references with all the state, getters, and plugin-added
+state properties of the store. Similar to `toRefs()` but specifically
+designed for Pinia stores so methods and non reactive properties are
+completely ignored.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `SS` | extends [`_StoreWithState`](../interfaces/pinia._StoreWithState.md)<`string`, [`StateTree`](pinia.md#statetree), [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, [`_ActionsTree`](pinia.md#_actionstree), `SS`\> & [`StateTree`](pinia.md#statetree) & [`_StoreWithGetters`](pinia.md#_storewithgetters)<[`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>\> & [`PiniaCustomProperties`](../interfaces/pinia.PiniaCustomProperties.md)<`string`, [`StateTree`](pinia.md#statetree), [`_GettersTree`](pinia.md#_getterstree)<[`StateTree`](pinia.md#statetree)\>, [`_ActionsTree`](pinia.md#_actionstree), `SS`\> & [`PiniaCustomStateProperties`](../interfaces/pinia.PiniaCustomStateProperties.md)<[`StateTree`](pinia.md#statetree), `SS`\> |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `store` | `SS` | store to extract the refs from |
+
+#### Returns
+
+`ToRefs`<[`StoreState`](pinia.md#storestate)<`SS`\> & [`StoreGetters`](pinia.md#storegetters)<`SS`\> & [`PiniaCustomStateProperties`](../interfaces/pinia.PiniaCustomStateProperties.md)<[`StoreState`](pinia.md#storestate)<`SS`\>\>\>

--- a/packages/docs/ja/api/modules/pinia_nuxt.md
+++ b/packages/docs/ja/api/modules/pinia_nuxt.md
@@ -1,0 +1,31 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / @pinia/nuxt
+
+# Module: @pinia/nuxt
+
+## Interfaces
+
+- [ModuleOptions](../interfaces/pinia_nuxt.ModuleOptions.md)
+
+## Functions
+
+### default
+
+▸ **default**(`this`, `inlineOptions`, `nuxt`): `void` \| `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `void` |
+| `inlineOptions` | [`ModuleOptions`](../interfaces/pinia_nuxt.ModuleOptions.md) |
+| `nuxt` | `Nuxt` |
+
+#### Returns
+
+`void` \| `Promise`<`void`\>

--- a/packages/docs/ja/api/modules/pinia_testing.md
+++ b/packages/docs/ja/api/modules/pinia_testing.md
@@ -1,0 +1,39 @@
+---
+sidebar: "auto"
+editLinks: false
+sidebarDepth: 3
+---
+
+[API Documentation](../index.md) / @pinia/testing
+
+# Module: @pinia/testing
+
+## Interfaces
+
+- [TestingOptions](../interfaces/pinia_testing.TestingOptions.md)
+- [TestingPinia](../interfaces/pinia_testing.TestingPinia.md)
+
+## Functions
+
+### createTestingPinia
+
+▸ **createTestingPinia**(`options?`): [`TestingPinia`](../interfaces/pinia_testing.TestingPinia.md)
+
+Creates a pinia instance designed for unit tests that **requires mocking**
+the stores. By default, **all actions are mocked** and therefore not
+executed. This allows you to unit test your store and components separately.
+You can change this with the `stubActions` option. If you are using jest,
+they are replaced with `jest.fn()`, otherwise, you must provide your own
+`createSpy` option.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | [`TestingOptions`](../interfaces/pinia_testing.TestingOptions.md) | options to configure the testing pinia |
+
+#### Returns
+
+[`TestingPinia`](../interfaces/pinia_testing.TestingPinia.md)
+
+a augmented pinia instance

--- a/packages/docs/ja/cookbook/composables.md
+++ b/packages/docs/ja/cookbook/composables.md
@@ -1,0 +1,99 @@
+# コンポーザブルへの対応 {#dealing-with-composables}
+
+[コンポーザブル](https://ja.vuejs.org/guide/reusability/composables.html#composables) は、Vue Composition APIを利用して、ステートフルなロジックをカプセル化して再利用するための関数です。自分で書くか、[外部ライブラリ](https://vueuse.org/) を使用するか、またはその両方を行うかにかかわらず、pinia ストアで Composables の力を十分に活用することができます。
+
+## Option ストア {#option-stores}
+
+Option ストアを定義する場合、`state` プロパティの内部でコンポーザブルを呼び出すことができます:
+
+```ts
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    user: useLocalStorage('pinia/auth/login', 'bob'),
+  }),
+})
+```
+
+**書き込み可能なステートしか返せない**（例: `ref()`）ことに留意してください。以下に、使用できるコンポーザブルの例を示します:
+
+- [useLocalStorage](https://vueuse.org/core/useLocalStorage/)
+- [useAsyncState](https://vueuse.org/core/useAsyncState/)
+
+ここでは、Option ストアで使用できない（Setup ストアでは使用できる）コンポーザブルの例を紹介します:
+
+- [useMediaControls](https://vueuse.org/core/useMediaControls/): exposes functions
+- [useMemoryInfo](https://vueuse.org/core/useMemory/): exposes readonly data
+- [useEyeDropper](https://vueuse.org/core/useEyeDropper/): exposes readonly data and functions
+
+## Setup ストア {#setup-stores}
+
+一方、Setup ストアの定義では、すべてのプロパティがステート、アクション、ゲッターに区別されるため、ほぼすべてのコンポーザブルを使用することができます:
+
+```ts
+import { defineStore, skipHydrate } from 'pinia'
+import { useMediaControls } from '@vueuse/core'
+
+export const useVideoPlayer = defineStore('video', () => {
+  // we won't expose this element directly
+  const videoElement = ref<HTMLVideoElement>()
+  const src = ref('/data/video.mp4')
+  const { playing, volume, currentTime, togglePictureInPicture } =
+    useMediaControls(video, { src })
+
+  function loadVideo(element: HTMLVideoElement, src: string) {
+    videoElement.value = element
+    src.value = src
+  }
+
+  return {
+    src,
+    playing,
+    volume,
+    currentTime,
+
+    loadVideo,
+    togglePictureInPicture,
+  }
+})
+```
+
+## SSR {#ssr}
+
+[Server Side Rendering](../ssr/index.md) を扱う場合、ストア内でコンポーザブルを使用するために、いくつかの追加手順を行う必要があります。
+
+[Option ストア](#option-stores) では、`hydrate()` 関数を定義する必要があります。この関数は、ストアがクライアント（ブラウザ）上でインスタンス化されるとき、ストアが作成された時点で利用可能な初期状態がある場合に呼び出されます。この関数を定義する必要があるのは、このようなシナリオでは `state()` が呼び出されないからです。
+
+```ts
+import { defineStore, skipHydrate } from 'pinia'
+import { useLocalStorage } from '@vueuse/core'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    user: useLocalStorage('pinia/auth/login', 'bob'),
+  }),
+
+  hydrate(state, initialState) {
+    // in this case we can completely ignore the initial state since we
+    // want to read the value from the browser
+    state.user = useLocalStorage('pinia/auth/login', 'bob')
+  },
+})
+```
+
+[Setup ストア](#setup-stores) では、初期状態からピックアップされるべきではないステートのプロパティに対して `skipHydrate()` という名前のヘルパーを使用する必要があります。Option ストアとは異なり、Setup ストアは単に _`state()` の呼び出しをスキップ_ することはできませんので、`skipHydrate()` でハイドレートできないプロパティをマークします。これは書き込み可能なリアクティブプロパティにのみ適用されることに注意してください:
+
+```ts
+import { defineStore, skipHydrate } from 'pinia'
+import { useEyeDropper, useLocalStorage } from '@vueuse/core'
+
+export const useColorStore = defineStore('colors', () => {
+  const { isSupported, open, sRGBHex } = useEyeDropper()
+  const lastColor = useLocalStorage('lastColor', sRGBHex)
+  // ...
+  return {
+    lastColor: skipHydrate(lastColor), // Ref<string>
+    open, // Function
+    isSupported, // boolean (not even reactive)
+  }
+})
+```

--- a/packages/docs/ja/cookbook/composing-stores.md
+++ b/packages/docs/ja/cookbook/composing-stores.md
@@ -1,0 +1,109 @@
+# Composing Stores {#composing-stores}
+
+ストアを構成するということは、お互いに利用し合うストアを持つことであり、Pinia ではこれをサポートしています。守るべきルールは 1 つです:
+
+**2 つ以上のストアがお互いを使用する** 場合、_ゲッター_ や _アクション_ によって無限ループを作ることはできません。また、セットアップ関数で **互いの** 状態を直接読み取ることもできません:
+
+```js
+const useX = defineStore('x', () => {
+  const y = useY()
+
+  // ❌ This is not possible because y also tries to read x.name
+  y.name
+
+  function doSomething() {
+    // ✅ Read y properties in computed or actions
+    const yName = y.name
+    // ...
+  }
+
+  return {
+    name: ref('I am X'),
+  }
+})
+
+const useY = defineStore('y', () => {
+  const x = useX()
+
+  // ❌ This is not possible because x also tries to read y.name
+  x.name
+
+  function doSomething() {
+    // ✅ Read x properties in computed or actions
+    const xName = x.name
+    // ...
+  }
+
+  return {
+    name: ref('I am Y'),
+  }
+})
+```
+
+## ネストしたストア {#nested-stores}
+
+あるストアが別のストアを使用する場合、_アクション_ と _ゲッター_ 内で `useStore()` 関数を直接インポートして呼び出すことができることに注意してください。そうすると、Vue コンポーネント内から操作するのと同じように、ストアを操作することができます。[共有ゲッター](#shared-getters) と [共有アクション](#shared-actions) を参照してください。
+
+_ストアの設定_ に関しては、ストア機能の **上部にある** ストアのいずれかを使用すればよいだけです。
+
+```ts
+import { useUserStore } from './user'
+
+export const useCartStore = defineStore('cart', () => {
+  const user = useUserStore()
+
+  const summary = computed(() => {
+    return `Hi ${user.name}, you have ${state.list.length} items in your cart. It costs ${state.price}.`
+  })
+
+  function purchase() {
+    return apiPurchase(user.id, this.list)
+  }
+
+  return { summary, purchase }
+})
+```
+
+## 共有ゲッター {#shared-getters}
+
+_ゲッター_ の中で `useOtherStore()` を呼び出すだけです:
+
+```js
+import { defineStore } from 'pinia'
+import { useUserStore } from './user'
+
+export const useCartStore = defineStore('cart', {
+  getters: {
+    summary(state) {
+      const user = useUserStore()
+
+      return `Hi ${user.name}, you have ${state.list.length} items in your cart. It costs ${state.price}.`
+    },
+  },
+})
+```
+
+## 共有アクション {#shared-actions}
+
+_アクション_ も同様です:
+
+```js
+import { defineStore } from 'pinia'
+import { useUserStore } from './user'
+
+export const useCartStore = defineStore('cart', {
+  actions: {
+    async orderCart() {
+      const user = useUserStore()
+
+      try {
+        await apiOrderCart(user.token, this.items)
+        // another action
+        this.emptyCart()
+      } catch (err) {
+        displayError(err)
+      }
+    },
+  },
+})
+```

--- a/packages/docs/ja/cookbook/hot-module-replacement.md
+++ b/packages/docs/ja/cookbook/hot-module-replacement.md
@@ -1,0 +1,20 @@
+# HMR (Hot Module Replacement) {#hmr-hot-module-replacement}
+
+Pinia は Hot Module replacement サポートしているので、ページを再読み込みすることなく、アプリ内で直接ストアを編集して操作できます。既存のステートを維持し、ステート、アクション、ゲッターを追加、または削除することも可能です。
+
+現時点では [Vite](https://ja.vitejs.dev/) のみが公式にサポートされていますが、`import.meta.hot` 仕様を実装したバンドラーであれば動作するはずです（例: [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) は `import.meta.hot` の代わりに `import.meta.webpackHot` を使っているようです）。
+このコードスニペットは、任意のストアの宣言の次に追加する必要があります。例えば、`auth.js`、`cart.js`、`chat.js` の 3 つのストアがあるとすると、ストア定義の作成後にこれを追加（および適応）する必要があります:
+
+```js
+// auth.js
+import { defineStore, acceptHMRUpdate } from 'pinia'
+
+const useAuth = defineStore('auth', {
+  // options...
+})
+
+// make sure to pass the right store definition, `useAuth` in this case.
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAuth, import.meta.hot))
+}
+```

--- a/packages/docs/ja/cookbook/index.md
+++ b/packages/docs/ja/cookbook/index.md
@@ -1,0 +1,8 @@
+# Cookbook
+
+- [Migrating from Vuex ≤4](./migration-vuex.md): A migration guide for converting Vuex ≤4 projects.
+- [HMR](./hot-module-replacement.md): How to activate hot module replacement and improve the developer experience.
+- [Testing Stores (WIP)](./testing.md): How to unit test Stores and mock them in component unit tests.
+- [Composing Stores](./composing-stores.md): How to cross use multiple stores. e.g. using the user store in the cart store.
+- [Options API](./options-api.md): How to use Pinia without the composition API, outside of `setup()`.
+- [Migrating from 0.0.7](./migration-0-0-7.md): A migration guide with more examples than the changelog.

--- a/packages/docs/ja/cookbook/migration-0-0-7.md
+++ b/packages/docs/ja/cookbook/migration-0-0-7.md
@@ -1,0 +1,122 @@
+# Migrating from 0.0.7
+
+The versions after `0.0.7`: `0.1.0`, and `0.2.0`, came with a few big breaking changes. This guide helps you migrate whether you use Vue 2 or Vue 3. The whole changelog can be found in the repository:
+
+- [For Pinia <= 1 for Vue 2](https://github.com/vuejs/pinia/blob/v1/CHANGELOG.md)
+- [For Pinia >= 2 for Vue 3](https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md)
+
+If you have questions or issues regarding the migration, feel free to [open a discussion](https://github.com/vuejs/pinia/discussions/categories/q-a) to ask for help.
+
+## No more `store.state`
+
+You no longer access the store state via a `state` property, you can directly access any state property.
+
+Given a store defined with:
+
+```js
+const useStore({
+  id: 'main',
+  state: () => ({ count: 0 })
+})
+```
+
+Do
+
+```diff
+ const store = useStore()
+
+-store.state.count++
++store.count.++
+```
+
+You can still access the whole store state with `$state` when needed:
+
+```diff
+-store.state = newState
++store.$state = newState
+```
+
+## Rename of store properties
+
+All store properties (`id`, `patch`, `reset`, etc) are now prefixed with `$` to allow properties defined on the store with the same names. Tip: you can refactor your whole codebase with F2 (or right-click + Refactor) on each of the store's properties
+
+```diff
+ const store = useStore()
+-store.patch({ count: 0 })
++store.$patch({ count: 0 })
+
+-store.reset()
++store.$reset()
+
+-store.id
++store.$id
+```
+
+## The Pinia instance
+
+It's now necessary to create a pinia instance and install it:
+
+If you are using Vue 2 (Pinia <= 1):
+
+```js
+import Vue from 'vue'
+import { createPinia, PiniaVuePlugin } from 'pinia'
+
+const pinia = createPinia()
+Vue.use(PiniaVuePlugin)
+new Vue({
+  el: '#app',
+  pinia,
+  // ...
+})
+```
+
+If you are using Vue 3 (Pinia >= 2):
+
+```js
+import { createApp } from 'vue'
+import { createPinia, PiniaVuePlugin } from 'pinia'
+import App from './App.vue'
+
+const pinia = createPinia()
+createApp(App).use(pinia).mount('#app')
+```
+
+The `pinia` instance is what holds the state and should **be unique per application**. Check the SSR section of the docs for more details.
+
+## SSR changes
+
+The SSR plugin `PiniaSsr` is no longer necessary and has been removed.
+With the introduction of pinia instances, `getRootState()` is no longer necessary and should be replaced with `pinia.state.value`:
+
+If you are using Vue 2 (Pinia <= 1):
+
+```diff
+// entry-server.js
+-import { getRootState, PiniaSsr } from 'pinia',
++import { createPinia, PiniaVuePlugin } from 'pinia',
+
+
+-// install plugin to automatically use correct context in setup and onServerPrefetch
+-Vue.use(PiniaSsr);
++Vue.use(PiniaVuePlugin)
+
+ export default context => {
++  const pinia = createPinia()
+   const app = new Vue({
+     // other options
++    pinia
+   })
+
+   context.rendered = () => {
+     // pass state to context
+-    context.piniaState = getRootState(context.req)
++    context.piniaState = pinia.state.value
+   };
+
+-   return { app }
++   return { app, pinia }
+ }
+```
+
+`setActiveReq()` and `getActiveReq()` have been replaced with `setActivePinia()` and `getActivePinia()` respectively. `setActivePinia()` can only be passed a `pinia` instance created with `createPinia()`. **Note that most of the time you won't directly use these functions**.

--- a/packages/docs/ja/cookbook/migration-v1-v2.md
+++ b/packages/docs/ja/cookbook/migration-v1-v2.md
@@ -1,0 +1,178 @@
+# Migrating from 0.x (v1) to v2
+
+Starting at version `2.0.0-rc.4`, pinia supports both Vue 2 and Vue 3! This means, all new updates will be applied to this version 2 so both Vue 2 and Vue 3 users can benefit from it. If you are using Vue 3, this doesn't change anything for you as you were already using the rc and you can check [the CHANGELOG](https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md) for a detailed explanation of everything that changed. Otherwise, **this guide is for you**!
+
+## Deprecations
+
+Let's take a look at all the changes you need to apply to your code. First, make sure you are already running the latest 0.x version to see any deprecations:
+
+```shell
+npm i 'pinia@^0.x.x'
+# or with yarn
+yarn add 'pinia@^0.x.x'
+```
+
+If you are using ESLint, consider using [this plugin](https://github.com/gund/eslint-plugin-deprecation) to find all deprecated usages. Otherwise, you should be able to see them as they appear crossed. These are the APIs that were deprecated that were removed:
+
+- `createStore()` becomes `defineStore()`
+- In subscriptions, `storeName` becomes `storeId`
+- `PiniaPlugin` was renamed `PiniaVuePlugin` (Pinia plugin for Vue 2)
+- `$subscribe()` no longer accepts a _boolean_ as second parameter, pass an object with `detached: true` instead.
+- Pinia plugins no longer directly receive the `id` of the store. Use `store.$id` instead.
+
+## Breaking changes
+
+After removing these, you can upgrade to v2 with:
+
+```shell
+npm i 'pinia@^2.x.x'
+# or with yarn
+yarn add 'pinia@^2.x.x'
+```
+
+And start updating your code.
+
+### Generic Store type
+
+Added in [2.0.0-rc.0](https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md#200-rc0-2021-07-28)
+
+Replace any usage of the type `GenericStore` with `StoreGeneric`. This is the new generic store type that should accept any kind of store. If you were writing functions using the type `Store` without passing its generics (e.g. `Store<Id, State, Getters, Actions>`), you should also use `StoreGeneric` as the `Store` type without generics creates an empty store type.
+
+```diff
+-function takeAnyStore(store: Store) {}
++function takeAnyStore(store: StoreGeneric) {}
+
+-function takeAnyStore(store: GenericStore) {}
++function takeAnyStore(store: StoreGeneric) {}
+```
+
+## `DefineStoreOptions` for plugins
+
+If you were writing plugins, using TypeScript, and extending the type `DefineStoreOptions` to add custom options, you should rename it to `DefineStoreOptionsBase`. This type will apply to both setup and options stores.
+
+```diff
+ declare module 'pinia' {
+-  export interface DefineStoreOptions<S, Store> {
++  export interface DefineStoreOptionsBase<S, Store> {
+     debounce?: {
+       [k in keyof StoreActions<Store>]?: number
+     }
+   }
+ }
+```
+
+## `PiniaStorePlugin` was renamed
+
+The type `PiniaStorePlugin` was renamed to `PiniaPlugin`.
+
+```diff
+-import { PiniaStorePlugin } from 'pinia'
++import { PiniaPlugin } from 'pinia'
+
+-const piniaPlugin: PiniaStorePlugin = () => {
++const piniaPlugin: PiniaPlugin = () => {
+   // ...
+ }
+```
+
+**Note this change can only be done after upgrading to the latest version of Pinia without deprecations**.
+
+## `@vue/composition-api` version
+
+Since pinia now relies on `effectScope()`, you must use at least the version `1.1.0` of `@vue/composition-api`:
+
+```shell
+npm i @vue/composition-api@latest
+# or with yarn
+yarn add @vue/composition-api@latest
+```
+
+## webpack 4 support
+
+If you are using webpack 4 (Vue CLI uses webpack 4), you might encounter an error like this:
+
+```
+ERROR  Failed to compile with 18 errors
+
+ error  in ./node_modules/pinia/dist/pinia.mjs
+
+Can't import the named export 'computed' from non EcmaScript module (only default export is available)
+```
+
+This is due to the modernization of dist files to support native ESM modules in Node.js. Files are now using the extension `.mjs` and `.cjs` to let Node benefit from this. To fix this issue you have two possibilities:
+
+- If you are using Vue CLI 4.x, upgrade your dependencies. This should include the fix below.
+  - If upgrading is not possible for you, add this to your `vue.config.js`:
+    ```js
+    // vue.config.js
+    module.exports = {
+      configureWebpack: {
+        module: {
+          rules: [
+            {
+              test: /\.mjs$/,
+              include: /node_modules/,
+              type: 'javascript/auto',
+            },
+          ],
+        },
+      },
+    }
+    ```
+- If you are manually handling webpack, you will have to let it know how to handle `.mjs` files:
+  ```js
+  // webpack.config.js
+  module.exports = {
+    module: {
+      rules: [
+        {
+          test: /\.mjs$/,
+          include: /node_modules/,
+          type: 'javascript/auto',
+        },
+      ],
+    },
+  }
+  ```
+
+## Devtools
+
+Pinia v2 no longer hijacks Vue Devtools v5, it requires Vue Devtools v6. Find the download link on the [Vue Devtools documentation](https://devtools.vuejs.org/guide/installation.html#chrome) for the **beta channel** of the extension.
+
+## Nuxt
+
+If you are using Nuxt, pinia has now it's dedicated Nuxt package 🎉. Install it with:
+
+```shell
+npm i @pinia/nuxt
+# or with yarn
+yarn add @pinia/nuxt
+```
+
+Also make sure to **update your `@nuxtjs/composition-api` package**.
+
+Then adapt your `nuxt.config.js` and your `tsconfig.json` if you are using TypeScript:
+
+```diff
+ // nuxt.config.js
+ module.exports {
+   buildModules: [
+     '@nuxtjs/composition-api/module',
+-    'pinia/nuxt',
++    '@pinia/nuxt',
+   ],
+ }
+```
+
+```diff
+ // tsconfig.json
+ {
+   "types": [
+     // ...
+-    "pinia/nuxt/types"
++    "@pinia/nuxt"
+   ]
+ }
+```
+
+It is also recommended to give [the dedicated Nuxt section](../ssr/nuxt.md) a read.

--- a/packages/docs/ja/cookbook/migration-vuex.md
+++ b/packages/docs/ja/cookbook/migration-vuex.md
@@ -1,0 +1,287 @@
+# Migrating from Vuex ≤4
+
+Although the structure of Vuex and Pinia stores is different, a lot of the logic can be reused. This guide serves to help you through the process and point out some common gotchas that can appear.
+
+## Preparation
+
+First, follow the [Getting Started guide](../getting-started.md) to install Pinia.
+
+## Restructuring Modules to Stores
+
+Vuex has the concept of a single store with multiple _modules_. These modules can optionally be namespaced and even nested within each other.
+
+The easiest way to transition that concept to be used with Pinia is that each module you used previously is now a _store_. Each store requires an `id` which is similar to a namespace in Vuex. This means that each store is namespaced by design. Nested modules can also each become their own store. Stores that depend on each other will simply import the other store.
+
+How you choose to restructure your Vuex modules into Pinia stores is entirely up to you, but here is one suggestion:
+
+```bash
+# Vuex example (assuming namespaced modules)
+src
+└── store
+    ├── index.js           # Initializes Vuex, imports modules
+    └── modules
+        ├── module1.js     # 'module1' namespace
+        └── nested
+            ├── index.js   # 'nested' namespace, imports module2 & module3
+            ├── module2.js # 'nested/module2' namespace
+            └── module3.js # 'nested/module3' namespace
+
+# Pinia equivalent, note ids match previous namespaces
+src
+└── stores
+    ├── index.js          # (Optional) Initializes Pinia, does not import stores
+    ├── module1.js        # 'module1' id
+    ├── nested-module2.js # 'nestedModule2' id
+    ├── nested-module3.js # 'nestedModule3' id
+    └── nested.js         # 'nested' id
+```
+
+This creates a flat structure for stores but also preserves the previous namespacing with equivalent `id`s. If you had some state/getters/actions/mutations in the root of the store (in the `store/index.js` file of Vuex) you may wish to create another store called something like `root` which holds all that information.
+
+The directory for Pinia is generally called `stores` instead of `store`. This is to emphasize that Pinia uses multiple stores, instead of a single store in Vuex.
+
+For large projects you may wish to do this conversion module by module rather than converting everything at once. You can actually mix Pinia and Vuex together during the migration so this approach can also work and is another reason for naming the Pinia directory `stores` instead.
+
+## Converting a Single Module
+
+Here is a complete example of the before and after of converting a Vuex module to a Pinia store, see below for a step-by-step guide. The Pinia example uses an option store as the structure is most similar to Vuex:
+
+```ts
+// Vuex module in the 'auth/user' namespace
+import { Module } from 'vuex'
+import { api } from '@/api'
+import { RootState } from '@/types' // if using a Vuex type definition
+
+interface State {
+  firstName: string
+  lastName: string
+  userId: number | null
+}
+
+const storeModule: Module<State, RootState> = {
+  namespaced: true,
+  state: {
+    firstName: '',
+    lastName: '',
+    userId: null
+  },
+  getters: {
+    firstName: (state) => state.firstName,
+    fullName: (state) => `${state.firstName} ${state.lastName}`,
+    loggedIn: (state) => state.userId !== null,
+    // combine with some state from other modules
+    fullUserDetails: (state, getters, rootState, rootGetters) => {
+      return {
+        ...state,
+        fullName: getters.fullName,
+        // read the state from another module named `auth`
+        ...rootState.auth.preferences,
+        // read a getter from a namespaced module called `email` nested under `auth`
+        ...rootGetters['auth/email'].details
+      }
+    }
+  },
+  actions: {
+    async loadUser ({ state, commit }, id: number) {
+      if (state.userId !== null) throw new Error('Already logged in')
+      const res = await api.user.load(id)
+      commit('updateUser', res)
+    }
+  },
+  mutations: {
+    updateUser (state, payload) {
+      state.firstName = payload.firstName
+      state.lastName = payload.lastName
+      state.userId = payload.userId
+    },
+    clearUser (state) {
+      state.firstName = ''
+      state.lastName = ''
+      state.userId = null
+    }
+  }
+}
+
+export default storeModule
+```
+
+```ts
+// Pinia Store
+import { defineStore } from 'pinia'
+import { useAuthPreferencesStore } from './auth-preferences'
+import { useAuthEmailStore } from './auth-email'
+import vuexStore from '@/store' // for gradual conversion, see fullUserDetails
+
+interface State {
+  firstName: string
+  lastName: string
+  userId: number | null
+}
+
+export const useAuthUserStore = defineStore('authUser', {
+  // convert to a function
+  state: (): State => ({
+    firstName: '',
+    lastName: '',
+    userId: null
+  }),
+  getters: {
+    // firstName getter removed, no longer needed
+    fullName: (state) => `${state.firstName} ${state.lastName}`,
+    loggedIn: (state) => state.userId !== null,
+    // must define return type because of using `this`
+    fullUserDetails (state): FullUserDetails {
+      // import from other stores
+      const authPreferencesStore = useAuthPreferencesStore()
+      const authEmailStore = useAuthEmailStore()
+      return {
+        ...state,
+        // other getters now on `this`
+        fullName: this.fullName,
+        ...authPreferencesStore.$state,
+        ...authEmailStore.details
+      }
+
+      // alternative if other modules are still in Vuex
+      // return {
+      //   ...state,
+      //   fullName: this.fullName,
+      //   ...vuexStore.state.auth.preferences,
+      //   ...vuexStore.getters['auth/email'].details
+      // }
+    }
+  },
+  actions: {
+    // no context as first argument, use `this` instead
+    async loadUser (id: number) {
+      if (this.userId !== null) throw new Error('Already logged in')
+      const res = await api.user.load(id)
+      this.updateUser(res)
+    },
+    // mutations can now become actions, instead of `state` as first argument use `this`
+    updateUser (payload) {
+      this.firstName = payload.firstName
+      this.lastName = payload.lastName
+      this.userId = payload.userId
+    },
+    // easily reset state using `$reset`
+    clearUser () {
+      this.$reset()
+    }
+  }
+})
+```
+
+Let's break the above down into steps:
+
+1. Add a required `id` for the store, you may wish to keep this the same as the namespace before. It is also recommended to make sure the `id` is in _camelCase_ as it makes it easier to use with `mapStores()`.
+2. Convert `state` to a function if it was not one already
+3. Convert `getters`
+    1. Remove any getters that return state under the same name (eg. `firstName: (state) => state.firstName`), these are not necessary as you can access any state directly from the store instance
+    2. If you need to access other getters, they are on `this` instead of using the second argument. Remember that if you are using `this` then you will have to use a regular function instead of an arrow function. Also note that you will need to specify a return type because of TS limitations, see [here](../core-concepts/getters.md#accessing-other-getters) for more details
+    3. If using `rootState` or `rootGetters` arguments, replace them by importing the other store directly, or if they still exist in Vuex then access them directly from Vuex
+4. Convert `actions`
+    1. Remove the first `context` argument from each action. Everything should be accessible from `this` instead
+    2. If using other stores either import them directly or access them on Vuex, the same as for getters
+5. Convert `mutations`
+    1. Mutations do not exist any more. These can be converted to `actions` instead, or you can just assign directly to the store within your components (eg. `userStore.firstName = 'First'`)
+    2. If converting to actions, remove the first `state` argument and replace any assignments with `this` instead
+    3. A common mutation is to reset the state back to its initial state. This is built in functionality with the store's `$reset` method. Note that this functionality only exists for option stores.
+
+As you can see most of your code can be reused. Type safety should also help you identify what needs to be changed if anything is missed.
+
+## Usage Inside Components
+
+Now that your Vuex module has been converted to a Pinia store, any component or other file that uses that module needs to be updated too.
+
+If you were using `map` helpers from Vuex before, it's worth looking at the [Usage without setup() guide](./options-api.md) as most of those helpers can be reused.
+
+If you were using `useStore` then instead import the new store directly and access the state on it. For example:
+
+```ts
+// Vuex
+import { defineComponent, computed } from 'vue'
+import { useStore } from 'vuex'
+
+export default defineComponent({
+  setup () {
+    const store = useStore()
+
+    const firstName = computed(() => store.state.auth.user.firstName)
+    const fullName = computed(() => store.getters['auth/user/fullName'])
+
+    return {
+      firstName,
+      fullName
+    }
+  }
+})
+```
+
+```ts
+// Pinia
+import { defineComponent, computed } from 'vue'
+import { useAuthUserStore } from '@/stores/auth-user'
+
+export default defineComponent({
+  setup () {
+    const authUserStore = useAuthUserStore()
+
+    const firstName = computed(() => authUserStore.firstName)
+    const fullName = computed(() => authUserStore.fullName)
+
+    return {
+      // you can also access the whole store in your component by returning it
+      authUserStore,
+      firstName,
+      fullName
+    }
+  }
+})
+```
+
+## Usage Outside Components
+
+Updating usage outside of components should be simple as long as you're careful to _not use a store outside of functions_. Here is an example of using the store in a Vue Router navigation guard:
+
+```ts
+// Vuex
+import vuexStore from '@/store'
+
+router.beforeEach((to, from, next) => {
+  if (vuexStore.getters['auth/user/loggedIn']) next()
+  else next('/login')
+})
+```
+
+```ts
+// Pinia
+import { useAuthUserStore } from '@/stores/auth-user'
+
+router.beforeEach((to, from, next) => {
+  // Must be used within the function!
+  const authUserStore = useAuthUserStore()
+  if (authUserStore.loggedIn) next()
+  else next('/login')
+})
+```
+
+More details can be found [here](../core-concepts/outside-component-usage.md).
+
+## Advanced Vuex Usage
+
+In the case your Vuex store using some of the more advanced features it offers, here is some guidance on how to accomplish the same in Pinia. Some of these points are already covered in [this comparison summary](../introduction.md#comparison-with-vuex-3-x-4-x).
+
+### Dynamic Modules
+
+There is no need to dynamically register modules in Pinia. Stores are dynamic by design and are only registered when they are needed. If a store is never used, it will never be "registered".
+
+### Hot Module Replacement
+
+HMR is also supported but will need to be replaced, see the [HMR Guide](./hot-module-replacement.md).
+
+### Plugins
+
+If you use a public Vuex plugin then check if there is a Pinia alternative. If not you will need to write your own or evaluate whether the plugin is still necessary.
+
+If you have written a plugin of your own, then it can likely be updated to work with Pinia. See the [Plugin Guide](../core-concepts/plugins.md).

--- a/packages/docs/ja/cookbook/options-api.md
+++ b/packages/docs/ja/cookbook/options-api.md
@@ -1,0 +1,77 @@
+# Usage without `setup()`
+
+Pinia can be used even if you are not using the composition API (if you are using Vue <2.7, you still need to install the `@vue/composition-api` plugin though). While we recommend you give the Composition API a try and learn it, it might not be the time for you and your team yet, you might be in the process of migrating an application, or any other reason. There are a few functions:
+
+- [mapStores](#giving-access-to-the-whole-store)
+- [mapState](../core-concepts/state.md#usage-with-the-options-api)
+- [mapWritableState](../core-concepts/state.md#modifiable-state)
+- ⚠️ [mapGetters](../core-concepts/getters.md#without-setup) (just for migration convenience, use `mapState()` instead)
+- [mapActions](../core-concepts/actions.md#without-setup)
+
+## Giving access to the whole store
+
+If you need to access pretty much everything from the store, it might be too much to map every single property of the store... Instead you can get access to the whole store with `mapStores()`:
+
+```js
+import { mapStores } from 'pinia'
+
+// given two stores with the following ids
+const useUserStore = defineStore('user', {
+  // ...
+})
+const useCartStore = defineStore('cart', {
+  // ...
+})
+
+export default {
+  computed: {
+    // note we are not passing an array, just one store after the other
+    // each store will be accessible as its id + 'Store'
+    ...mapStores(useCartStore, useUserStore)
+  },
+
+  methods: {
+    async buyStuff() {
+      // use them anywhere!
+      if (this.userStore.isAuthenticated()) {
+        await this.cartStore.buy()
+        this.$router.push('/purchased')
+      }
+    },
+  },
+}
+```
+
+By default, Pinia will add the `"Store"` suffix to the `id` of each store. You can customize this behavior by calling the `setMapStoreSuffix()`:
+
+```js
+import { createPinia, setMapStoreSuffix } from 'pinia'
+
+// completely remove the suffix: this.user, this.cart
+setMapStoreSuffix('')
+// this.user_store, this.cart_store (it's okay, I won't judge you)
+setMapStoreSuffix('_store')
+export const pinia = createPinia()
+```
+
+## TypeScript
+
+By default, all map helpers support autocompletion and you don't need to do anything. If you call `setMapStoreSuffix()` to change the `"Store"` suffix, you will need to also add it somewhere in a TS file or your `global.d.ts` file. The most convenient place would be the same place where you call `setMapStoreSuffix()`:
+
+```ts
+import { createPinia, setMapStoreSuffix } from 'pinia'
+
+setMapStoreSuffix('') // completely remove the suffix
+export const pinia = createPinia()
+
+declare module 'pinia' {
+  export interface MapStoresCustomization {
+    // set it to the same value as above
+    suffix: ''
+  }
+}
+```
+
+:::warning
+If you are using a TypeScript declaration file (like `global.d.ts`), make sure to `import 'pinia'` at the top of it to expose all existing types.
+:::

--- a/packages/docs/ja/cookbook/testing.md
+++ b/packages/docs/ja/cookbook/testing.md
@@ -1,0 +1,252 @@
+# ストアのテスト {#testing-stores}
+
+ストアは、設計上、多くの場所で使用されることになり、テストを必要以上に難しくしてしまうことがあります。幸いなことに、そのようなことはありません。ストアをテストする際には、3 つのことに気をつける必要があります:
+
+- `pinia` インスタンス: これがないとストアは成り立たない
+- `actions`: ほとんどの場合、ストアの最も複雑なロジックを含んでいます。もし、デフォルトでモック化されていたらいいと思いませんか？
+- プラグイン: プラグインに依存している場合、テスト用にプラグインをインストールする必要があります
+
+何をどのようにテストしているかに応じて、これら 3 つを異なる方法で処理する必要があります:
+
+- [ストアのテスト {#testing-stores}](#ストアのテスト-testing-stores)
+  - [ストアのユニットテスト {#unit-testing-a-store}](#ストアのユニットテスト-unit-testing-a-store)
+  - [コンポーネントのユニットテスト {#unit-testing-components}](#コンポーネントのユニットテスト-unit-testing-components)
+    - [初期状態 {#initial-state}](#初期状態-initial-state)
+    - [アクションの動作のカスタマイズ {#customizing-behavior-of-actions}](#アクションの動作のカスタマイズ-customizing-behavior-of-actions)
+    - [createSpy 関数の指定 {#specifying-the-create-spy-function}](#createspy-関数の指定-specifying-the-create-spy-function)
+    - [ゲッターのモック化 {#mocking-getters}](#ゲッターのモック化-mocking-getters)
+    - [Pinia プラグイン {#pinia-plugins}](#pinia-プラグイン-pinia-plugins)
+  - [E2E テスト {#e2-e-tests}](#e2e-テスト-e2-e-tests)
+  - [コンポーネントのユニットテスト（Vue 2） {#unit-test-components-vue-2}](#コンポーネントのユニットテストvue-2-unit-test-components-vue-2)
+
+## ストアのユニットテスト {#unit-testing-a-store}
+
+ストアをユニットテストするために、最も重要な部分は、`pinia` のインスタンスを作成することです:
+
+```js
+// stores/counter.spec.ts
+import { setActivePinia, createPinia } from 'pinia'
+import { useCounter } from '../src/stores/counter'
+
+describe('Counter Store', () => {
+  beforeEach(() => {
+    // creates a fresh pinia and make it active so it's automatically picked
+    // up by any useStore() call without having to pass it to it:
+    // `useStore(pinia)`
+    setActivePinia(createPinia())
+  })
+
+  it('increments', () => {
+    const counter = useCounter()
+    expect(counter.n).toBe(0)
+    counter.increment()
+    expect(counter.n).toBe(1)
+  })
+
+  it('increments by amount', () => {
+    const counter = useCounter()
+    counter.increment(10)
+    expect(counter.n).toBe(10)
+  })
+})
+```
+
+ストアプラグインがある場合、1 つ重要なことがあります: **プラグインは、`pinia` がアプリにインストールされるまで使用されません**。これは、空のアプリまたは偽のアプリを作成することで解決できます:
+
+```js
+import { setActivePinia, createPinia } from 'pinia'
+import { createApp } from 'vue'
+import { somePlugin } from '../src/stores/plugin'
+
+// same code as above...
+
+// you don't need to create one app per test
+const app = createApp({})
+beforeEach(() => {
+  const pinia = createPinia().use(somePlugin)
+  app.use(pinia)
+  setActivePinia(pinia)
+})
+```
+
+## コンポーネントのユニットテスト {#unit-testing-components}
+
+これは `createTestingPinia()` で実現でき、コンポーネントのユニットテストを支援するために設計された pinia インスタンスを返します。
+
+まず、`@pinia/testing` をインストールします:
+
+```shell
+npm i -D @pinia/testing
+```
+
+また、コンポーネントをマウントする際には、必ずテスト用の pinia をテストに作成してください:
+
+```js
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+// import any store you want to interact with in tests
+import { useSomeStore } from '@/stores/myStore'
+
+const wrapper = mount(Counter, {
+  global: {
+    plugins: [createTestingPinia()],
+  },
+})
+
+const store = useSomeStore() // uses the testing pinia!
+
+// state can be directly manipulated
+store.name = 'my new name'
+// can also be done through patch
+store.$patch({ name: 'new name' })
+expect(store.name).toBe('new name')
+
+// actions are stubbed by default, meaning they don't execute their code by default.
+// See below to customize this behavior.
+store.someAction()
+
+expect(store.someAction).toHaveBeenCalledTimes(1)
+expect(store.someAction).toHaveBeenLastCalledWith()
+```
+
+Vue 2 を使用している場合、`@vue/test-utils` は [少し異なる設定](#unit-test-components-vue-2) を必要としますので、注意してください。
+
+### 初期状態 {#initial-state}
+
+テスト用 pinia の作成時に `initialState` オブジェクトを渡すことで、**すべてのストア** の初期状態を設定することができます。このオブジェクトは、テスト用 pinia がストアを作成するときに _パッチ_ を適用するために使用されます。例えば、このストアの状態を初期化したいとします:
+
+```ts
+import { defineStore } from 'pinia'
+
+const useCounterStore = defineStore('counter', {
+  state: () => ({ n: 0 }),
+  // ...
+})
+```
+
+ストア名が _"counter"_ なので、`initialState` に一致するオブジェクトを追加する必要があります:
+
+```ts
+// somewhere in your test
+const wrapper = mount(Counter, {
+  global: {
+    plugins: [
+      createTestingPinia({
+        initialState: {
+          counter: { n: 20 }, // start the counter at 20 instead of 0
+        },
+      }),
+    ],
+  },
+})
+
+const store = useSomeStore() // uses the testing pinia!
+store.n // 20
+```
+
+### アクションの動作のカスタマイズ {#customizing-behavior-of-actions}
+
+`createTestingPinia` は、特に指示がない限りすべてのストアアクションをスタブ化します。これにより、コンポーネントとストアを別々にテストすることができます。
+
+この動作を元に戻して、テスト中に通常通りアクションを実行したい場合は、`createTestingPinia` の呼び出し時に `stubActions: false` を指定してください:
+
+```js
+const wrapper = mount(Counter, {
+  global: {
+    plugins: [createTestingPinia({ stubActions: false })],
+  },
+})
+
+const store = useSomeStore()
+
+// Now this call WILL execute the implementation defined by the store
+store.someAction()
+
+// ...but it's still wrapped with a spy, so you can inspect calls
+expect(store.someAction).toHaveBeenCalledTimes(1)
+```
+
+### createSpy 関数の指定 {#specifying-the-create-spy-function}
+
+Jest または vitest を `globals: true` で使用する場合、`createTestingPinia` は、既存のテストフレームワークに基づくスパイ関数（`jest.fn` または `vitest.fn`）を使用して、自動的にアクションをスタブ化します。別のフレームワークを使用している場合は、[createSpy](/ja/api/interfaces/pinia_testing.TestingOptions.html#createspy) オプションを指定する必要があります:
+
+```js
+import sinon from 'sinon'
+
+createTestingPinia({
+  createSpy: sinon.spy, // use sinon's spy to wrap actions
+})
+```
+
+[テストパッケージのテスト](https://github.com/vuejs/pinia/blob/v2/packages/testing/src/testing.spec.ts) に、より多くの例を見ることができます。
+
+### ゲッターのモック化 {#mocking-getters}
+
+デフォルトでは、どのゲッターも通常の使用方法と同じように計算されますが、ゲッターに好きな値を設定することで、手動で強制的に値を設定することができます:
+
+```ts
+import { defineStore } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+
+const useCounter = defineStore('counter', {
+  state: () => ({ n: 1 }),
+  getters: {
+    double: (state) => state.n * 2,
+  },
+})
+
+const pinia = createTestingPinia()
+const counter = useCounter(pinia)
+
+counter.double = 3 // 🪄 getters are writable only in tests
+
+// set to undefined to reset the default behavior
+// @ts-expect-error: usually it's a number
+counter.double = undefined
+counter.double // 2 (=1 x 2)
+```
+
+### Pinia プラグイン {#pinia-plugins}
+
+pinia プラグインがある場合、`createTestingPinia()` を呼び出すときにプラグインを渡して、正しく適用されるようにする必要があります。通常の pinia のように **`testingPinia.use(MyPlugin)` で追加しないでください**:
+
+```js
+import { createTestingPinia } from '@pinia/testing'
+import { somePlugin } from '../src/stores/plugin'
+
+// inside some test
+const wrapper = mount(Counter, {
+  global: {
+    plugins: [
+      createTestingPinia({
+        stubActions: false,
+        plugins: [somePlugin],
+      }),
+    ],
+  },
+})
+```
+
+## E2E テスト {#e2-e-tests}
+
+pinia に関しては、e2e テストのために何かを変更する必要はなく、それが e2e テストの要点です！HTTP リクエストをテストすることもできますが、それはこのガイドの範囲をはるかに超えています😄。
+
+## コンポーネントのユニットテスト（Vue 2） {#unit-test-components-vue-2}
+
+[Vue Test Utils 1](https://v1.test-utils.vuejs.org/) を使用する場合、Pinia は `localVue` にインストールしてください:
+
+```js
+import { PiniaVuePlugin } from 'pinia'
+import { createLocalVue, mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+
+const localVue = createLocalVue()
+localVue.use(PiniaVuePlugin)
+
+const wrapper = mount(Counter, {
+  localVue,
+  pinia: createTestingPinia(),
+})
+
+const store = useSomeStore() // uses the testing pinia!
+```

--- a/packages/docs/ja/core-concepts/actions.md
+++ b/packages/docs/ja/core-concepts/actions.md
@@ -1,0 +1,234 @@
+# アクション {#actions}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/synchronous-and-asynchronous-actions-in-pinia"
+  title="Learn all about actions in Pinia"
+/>
+
+アクションは、コンポーネントにおける [methods](https://ja.vuejs.org/guide/essentials/reactivity-fundamentals.html#declaring-methods) に相当します。`defineStore()` の `actions` プロパティで定義することができ、**ビジネスロジックを定義するのに最適です**。
+
+```js
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+  actions: {
+    // since we rely on `this`, we cannot use an arrow function
+    increment() {
+      this.count++
+    },
+    randomizeCounter() {
+      this.count = Math.round(100 * Math.random())
+    },
+  },
+})
+```
+
+[ゲッター](./getters.md) と同様に、アクションも `this` を通じて _ストアインスタンス全体_ にアクセスでき、**完全なタイピング（とオートコンプリート ✨）をサポートします**。**ゲッターとは異なり、 `アクション` は非同期であり**、アクションの中で任意の API コールや他のアクションを `待つ（await）` ことができます！以下は [Mande](https://github.com/posva/mande) を使った例です。`Promise` を取得できれば、使用するライブラリは問いません。ネイティブの`fetch` 関数（ブラウザのみ）を使用することもできます:
+
+```js
+import { mande } from 'mande'
+
+const api = mande('/api/users')
+
+export const useUsers = defineStore('users', {
+  state: () => ({
+    userData: null,
+    // ...
+  }),
+
+  actions: {
+    async registerUser(login, password) {
+      try {
+        this.userData = await api.post({ login, password })
+        showTooltip(`Welcome back ${this.userData.name}!`)
+      } catch (error) {
+        showTooltip(error)
+        // let the form component display the error
+        return error
+      }
+    },
+  },
+})
+```
+
+また、好きな引数を設定し、好きなものを返すことも完全に自由です。アクションを呼び出すときは、すべて自動的に推論されます！
+
+アクションはメソッドのように呼び出されます:
+
+```js
+export default defineComponent({
+  setup() {
+    const store = useCounterStore()
+    // call the action as a method of the store
+    store.randomizeCounter()
+
+    return {}
+  },
+})
+```
+
+## 他のストアのアクションへのアクセス {#accessing-other-stores-actions}
+
+他のストアを使用するには、_アクション_ の中で直接 _使用する_ ことができます:
+
+```js
+import { useAuthStore } from './auth-store'
+
+export const useSettingsStore = defineStore('settings', {
+  state: () => ({
+    preferences: null,
+    // ...
+  }),
+  actions: {
+    async fetchUserPreferences() {
+      const auth = useAuthStore()
+      if (auth.isAuthenticated) {
+        this.preferences = await fetchPreferences()
+      } else {
+        throw new Error('User must be authenticated')
+      }
+    },
+  },
+})
+```
+
+## `setup()` での使用方法 {#usage-with-setup}
+
+ストアのメソッドとして、任意のアクションを直接呼び出すことができます:
+
+```js
+export default {
+  setup() {
+    const store = useCounterStore()
+
+    store.randomizeCounter()
+  },
+}
+```
+
+## Options API での使用方法 {#usage-with-the-options-api}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/access-pinia-actions-in-the-options-api"
+  title="Access Pinia Getters via the Options API"
+/>
+
+以下の例では、以下のストアが作成されたと仮定しています:
+
+```js
+// Example File Path:
+// ./src/stores/counter.js
+
+import { defineStore } from 'pinia',
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0
+  }),
+  actions: {
+    increment() {
+      this.count++
+    }
+  }
+})
+```
+
+### With `setup()` {#with-setup}
+
+Composition API は万人向けではありませんが、`setup()` フックを使えば Options API で Pinia をより簡単に使えるようになります。余分なマップヘルパー関数は必要ありません！
+
+```js
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  setup() {
+    const counterStore = useCounterStore()
+
+    return { counterStore }
+  },
+  methods: {
+    incrementAndPrint() {
+      this.counterStore.increment()
+      console.log('New Count:', this.counterStore.count)
+    },
+  },
+}
+```
+
+### Without `setup()` {#without-setup}
+
+Composition API を一切使用しない場合は、`mapActions()` ヘルパーを使用して、アクションプロパティをコンポーネント内のメソッドとしてマッピングすることができます:
+
+```js
+import { mapActions } from 'pinia'
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  methods: {
+    // gives access to this.increment() inside the component
+    // same as calling from store.increment()
+    ...mapActions(useCounterStore, ['increment'])
+    // same as above but registers it as this.myOwnName()
+    ...mapActions(useCounterStore, { myOwnName: 'increment' }),
+  },
+}
+```
+
+## アクションの購読（Subscribing） {#subscribing-to-actions}
+
+`store.$onAction()` でアクションとその結果を観察することができます。これに渡されたコールバックは、アクション自体の前に実行されます。`after` ハンドルは、アクションの解決後に関数を実行できるようにします。同様に、`onError` では、アクションが throw または reject された場合に関数を実行することができます。これらは、[Vue のドキュメントにあるこのヒント](https://ja.vuejs.org/guide/best-practices/production-deployment.html#tracking-runtime-errors) と同様に、実行時にエラーを追跡するのに便利です。
+
+以下は、アクションの実行前と resolve/reject 後のログを記録する例です。
+
+```js
+const unsubscribe = someStore.$onAction(
+  ({
+    name, // name of the action
+    store, // store instance, same as `someStore`
+    args, // array of parameters passed to the action
+    after, // hook after the action returns or resolves
+    onError, // hook if the action throws or rejects
+  }) => {
+    // a shared variable for this specific action call
+    const startTime = Date.now()
+    // this will trigger before an action on `store` is executed
+    console.log(`Start "${name}" with params [${args.join(', ')}].`)
+
+    // this will trigger if the action succeeds and after it has fully run.
+    // it waits for any returned promised
+    after((result) => {
+      console.log(
+        `Finished "${name}" after ${
+          Date.now() - startTime
+        }ms.\nResult: ${result}.`
+      )
+    })
+
+    // this will trigger if the action throws or returns a promise that rejects
+    onError((error) => {
+      console.warn(
+        `Failed "${name}" after ${Date.now() - startTime}ms.\nError: ${error}.`
+      )
+    })
+  }
+)
+
+// manually remove the listener
+unsubscribe()
+```
+
+デフォルトでは、_アクションのサブスクリプション_ は、それらが追加されたコンポーネントにバインドされます（ストアがコンポーネントの `setup()` 内にある場合）。つまり、コンポーネントがアンマウントされると、自動的に削除されます。コンポーネントがアンマウントされた後もそれらを保持したい場合、第 2 引数として `true` を渡して、現在のコンポーネントから _アクションのサブスクリプション_ を _切り離し_ ます:
+
+```js
+export default {
+  setup() {
+    const someStore = useSomeStore()
+
+    // this subscription will be kept even after the component is unmounted
+    someStore.$onAction(callback, true)
+
+    // ...
+  },
+}
+```

--- a/packages/docs/ja/core-concepts/getters.md
+++ b/packages/docs/ja/core-concepts/getters.md
@@ -1,0 +1,236 @@
+# ゲッター {#getters}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/getters-in-pinia"
+  title="Learn all about getters in Pinia"
+/>
+
+ゲッターは、まさにストアのステートの [算出プロパティ](https://ja.vuejs.org/guide/essentials/computed.html) に相当するものです。`defineStore()` の `getters` プロパティで定義することができます。これらは、アロー関数の使用を **奨励する** ために、最初のパラメータとして `state` を受け取ります:
+
+```js
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+  getters: {
+    doubleCount: (state) => state.count * 2,
+  },
+})
+```
+
+ほとんどの場合、ゲッターはステートにのみ依存しますが、他のゲッターを使う必要がある場合もあります。このため、通常の関数を定義する場合、`this` を通じて _ストアインスタンス全体_ にアクセスすることができますが、 **戻り値の型を定義する必要があります（TypeScriptの場合）**。これは TypeScript の既知の制限によるもので、**アロー関数を用いて定義されたゲッターや、`this` を使わないゲッターには影響しません**:
+
+```ts
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+  getters: {
+    // automatically infers the return type as a number
+    doubleCount(state) {
+      return state.count * 2
+    },
+    // the return type **must** be explicitly set
+    doublePlusOne(): number {
+      // autocompletion and typings for the whole store ✨
+      return this.doubleCount + 1
+    },
+  },
+})
+```
+
+そして、ストアインスタンス上で直接ゲッターにアクセスすることができます:
+
+```vue
+<template>
+  <p>Double count is {{ store.doubleCount }}</p>
+</template>
+
+<script>
+export default {
+  setup() {
+    const store = useCounterStore()
+
+    return { store }
+  },
+}
+</script>
+```
+
+## 他のゲッターへのアクセス {#accessing-other-getters}
+
+算出プロパティと同様に、複数のゲッターを組み合わせることができます。他のゲッターには `this` を経由してアクセスします。TypeScript を使用していない場合でも、[JSDoc](https://jsdoc.app/tags-returns.html) を使用して IDE に型に関するヒントを与えることができます:
+
+```js
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+  getters: {
+    // type is automatically inferred because we are not using `this`
+    doubleCount: (state) => state.count * 2,
+    // here we need to add the type ourselves (using JSDoc in JS). We can also
+    // use this to document the getter
+    /**
+     * Returns the count value times two plus one.
+     *
+     * @returns {number}
+     */
+    doubleCountPlusOne() {
+      // autocompletion ✨
+      return this.doubleCount + 1
+    },
+  },
+})
+```
+
+## ゲッターに引数を渡す {#passing-arguments-to-getters}
+
+_ゲッター_ は裏側で _計算_ されるだけのプロパティなので、パラメータを渡すことはできません。しかし、_ゲッター_ から関数を返すことで、任意の引数を受け取ることができます:
+
+```js
+export const useStore = defineStore('main', {
+  getters: {
+    getUserById: (state) => {
+      return (userId) => state.users.find((user) => user.id === userId)
+    },
+  },
+})
+```
+
+コンポーネントで使用します:
+
+```vue
+<script>
+export default {
+  setup() {
+    const store = useStore()
+
+    return { getUserById: store.getUserById }
+  },
+}
+</script>
+
+<template>
+  <p>User 2: {{ getUserById(2) }}</p>
+</template>
+```
+
+この場合、**ゲッターはキャッシュされず**、単に呼び出される関数となることに注意してください。しかし、ゲッターの内部で結果をキャッシュすることは可能です。これは一般的ではありませんが、より高いパフォーマンスを発揮するはずです:
+
+```js
+export const useStore = defineStore('main', {
+  getters: {
+    getActiveUserById(state) {
+      const activeUsers = state.users.filter((user) => user.active)
+      return (userId) => activeUsers.find((user) => user.id === userId)
+    },
+  },
+})
+```
+
+## 他のストアのゲッターへのアクセス {#accessing-other-stores-getters}
+
+他のストアゲッターを使用するには、_ゲッター_ の内部で直接 _使用する_ ことができます:
+
+```js
+import { useOtherStore } from './other-store'
+
+export const useStore = defineStore('main', {
+  state: () => ({
+    // ...
+  }),
+  getters: {
+    otherGetter(state) {
+      const otherStore = useOtherStore()
+      return state.localData + otherStore.data
+    },
+  },
+})
+```
+
+## `setup()` での使用方法 {#usage-with-setup}
+
+ゲッターはストアのプロパティとして直接アクセスできます（ステートのプロパティと全く同じです）:
+
+```js
+export default {
+  setup() {
+    const store = useCounterStore()
+
+    store.count = 3
+    store.doubleCount // 6
+  },
+}
+```
+
+## Options API での使用方法 {#usage-with-the-options-api}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/access-pinia-getters-in-the-options-api"
+  title="Access Pinia Getters via the Options API"
+/>
+
+以下の例では、以下のストアが作成されたと仮定しています:
+
+```js
+// Example File Path:
+// ./src/stores/counter.js
+
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+  getters: {
+    doubleCount(state) {
+      return state.count * 2
+    },
+  },
+})
+```
+
+### With `setup()` {#with-setup}
+
+Composition API は万人向けではありませんが、`setup()` フックを使えば Options API で Pinia をより簡単に使えるようになります。余分なマップヘルパー関数は必要ありません！
+
+```js
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  setup() {
+    const counterStore = useCounterStore()
+
+    return { counterStore }
+  },
+  computed: {
+    quadrupleCounter() {
+      return this.counterStore.doubleCount * 2
+    },
+  },
+}
+```
+
+### Without `setup()` {#without-setup}
+
+ゲッターへのマッピングには、[前節のステート](./state.md#usage-with-the-options-api) で使用したのと同じ `mapState()` 関数を使用することができます:
+
+```js
+import { mapState } from 'pinia'
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  computed: {
+    // gives access to this.doubleCount inside the component
+    // same as reading from store.doubleCount
+    ...mapState(useCounterStore, ['doubleCount']),
+    // same as above but registers it as this.myOwnName
+    ...mapState(useCounterStore, {
+      myOwnName: 'doubleCount',
+      // you can also write a function that gets access to the store
+      double: (store) => store.doubleCount,
+    }),
+  },
+}
+```

--- a/packages/docs/ja/core-concepts/index.md
+++ b/packages/docs/ja/core-concepts/index.md
@@ -1,0 +1,158 @@
+# ストアの定義 {#defining-a-store}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/define-your-first-pinia-store"
+  title="Learn how to define and use stores in Pinia"
+/>
+
+コアコンセプトに入る前に、ストアは `defineStore()` で定義され、最初の引数として渡される **一意** の名称が必要であることを知る必要があります:
+
+```js
+import { defineStore } from 'pinia'
+
+// You can name the return value of `defineStore()` anything you want, 
+// but it's best to use the name of the store and surround it with `use` 
+// and `Store` (e.g. `useUserStore`, `useCartStore`, `useProductStore`)
+// the first argument is a unique id of the store across your application
+export const useAlertsStore = defineStore('alerts', {
+  // other options...
+})
+```
+
+_id_ とも呼ばれるこの _名前_ は必要であり、ストアを devtools に接続するために Pinia によって使用されます。返された関数の名前を _use..._ にすることは、その使用方法を慣用的にするためのコンポーザブル全体の規則です。
+
+`defineStore()` は第 2 引数に 2 つの異なる値 (Setup 関数、または Options オブジェクト) を受け入れます。
+
+## Option ストア {#option-stores}
+
+Vue の Options API と同様に、`state`、`action` そして `getters` プロパティを持つ Options オブジェクトを渡すこともできます。
+
+```js {2-10}
+export const useCounterStore = defineStore('counter', {
+  state: () => ({ count: 0, name: 'Eduardo' }),
+  getters: {
+    doubleCount: (state) => state.count * 2,
+  },
+  actions: {
+    increment() {
+      this.count++
+    },
+  },
+})
+```
+
+`state` はストアの `data`、`getters` はストアの `computed` プロパティ、`actions` は `methods` と考えることができます。
+
+Option ストアは、使い始めるのが直感的でシンプルに感じられる必要があります。
+
+## Setup ストア {#setup-stores}
+
+また、ストアを定義するための別の構文もあります。Vue Composition API の [setup 関数](https://ja.vuejs.org/api/composition-api-setup.html) と同様に、リアクティブなプロパティとメソッドを定義し、公開したいプロパティとメソッドを含むオブジェクトを返す関数を渡すことができます。
+
+```js
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0)
+  const name = ref('Eduardo')
+  const doubleCount = computed(() => count.value * 2)
+  function increment() {
+    count.value++
+  }
+
+  return { count, name, doubleCount, increment }
+})
+```
+
+_Setup ストア_ では:
+
+- `ref()` が `state` のプロパティとなります
+- `computed()` が `getters` となります
+- `function()` が `actions` となります
+
+Setup ストアは、ストアの中にウォッチャーを作ったり、[コンポーザブル](https://ja.vuejs.org/guide/reusability/composables.html#composables) を自由に使うことができるので、[Option ストア](#option-stores) に比べて柔軟性があります。しかし、[SSR](../cookbook/composables.md) を使う場合は、コンポーザブルの使い方がより複雑になることに注意してください。
+
+## どちらの構文を選択する？ {#what-syntax-should-i-pick}
+
+Vue の [Composition API と Options API](https://ja.vuejs.org/guide/introduction.html#which-to-choose) と同様に、最も使いやすいと感じるものを選んでください。よくわからない場合、最初に [Option ストア](#option-stores) を試してください。
+
+## ストアの利用 {#using-the-store}
+
+私達はストアを _定義_ しました。というのは `setup()` の内部で `use...Store()` が呼び出されるまでストアは作成されないからです:
+
+```js
+import { useCounterStore } from '@/stores/counter'
+
+export default {
+  setup() {
+    const store = useCounterStore()
+
+    return {
+      // you can return the whole store instance to use it in the template
+      store,
+    }
+  },
+}
+```
+
+:::tip
+まだ `setup` コンポーネントを使用していない場合でも、 [_マップヘルパー_ を使用して Pinia を使用することができます](../cookbook/options-api.md)。
+:::
+
+必要な数のストアを定義できますが、Pinia の機能を最大限に活用するには、 **それぞれのストアを別のファイルで定義する必要があります** （バンドラーのコード分割を自動的に許可したり、TypeScript の推論を提供するなど）。
+
+ストアをインスタンス化すると、`state`、`getters` そして `actions` で定義されたあらゆるプロパティにストア上で直接アクセスできるようになります。これらについては、次のページで詳しく見ていきますが、オートコンプリートが役に立ちます。
+
+`store` は `reactive` でラップされたオブジェクトであることに注意してください。つまり、getters の後に `.value` を記述する必要はありませんが、 `setup` の `props` のように、**それを分解することはできません**:
+
+```js
+export default defineComponent({
+  setup() {
+    const store = useCounterStore()
+    // ❌ This won't work because it breaks reactivity
+    // it's the same as destructuring from `props`
+    const { name, doubleCount } = store
+
+    name // "Eduardo"
+    doubleCount // 0
+
+    setTimeout(() => {
+      store.increment()
+    }, 1000)
+
+    return {
+      // will always be "Eduardo"
+      name,
+      // will always be 0
+      doubleCount,
+      // will also always be 0
+      doubleNumber: store.doubleCount,
+
+      // ✅ this one will be reactive
+      doubleValue: computed(() => store.doubleCount),
+    }
+  },
+})
+```
+
+リアクティビティ（反応性）を維持したままストアからプロパティを抽出するには、`storeToRefs()` を使用する必要があります。これは、すべてのリアクティブプロパティに対して refs を作成します。これは、ストアの状態のみを使用し、アクションを呼び出さない場合に便利です。アクションはストア自体にバインドされているので、ストアから直接アクションを分解できることに注意しましょう:
+
+```js
+import { storeToRefs } from 'pinia'
+
+export default defineComponent({
+  setup() {
+    const store = useCounterStore()
+    // `name` and `doubleCount` are reactive refs
+    // This will also create refs for properties added by plugins
+    // but skip any action or non reactive (non ref/reactive) property
+    const { name, doubleCount } = storeToRefs(store)
+    // the increment action can just be extracted
+    const { increment } = store
+
+    return {
+      name,
+      doubleCount,
+      increment,
+    }
+  },
+})
+```

--- a/packages/docs/ja/core-concepts/outside-component-usage.md
+++ b/packages/docs/ja/core-concepts/outside-component-usage.md
@@ -1,0 +1,59 @@
+# コンポーネント外部でストアを使用する {#using-a-store-outside-of-a-component}
+
+Pinia ストアは、すべての呼び出しで同じストアインスタンスを共有するために、`pinia` インスタンスに依存しています。ほとんどの場合、`useStore()` 関数を呼び出すだけで、すぐに動作するようになります。例えば、`setup()` では、他に何もする必要はありません。しかし、コンポーネントの外では少し事情が異なります。
+裏側では、`useStore()` が `app` に与えた `pinia` インスタンスを _注入_ しています。つまり、`pinia` インスタンスを自動的に注入できない場合は、手動で `useStore()` 関数に提供する必要があります。
+作成しているアプリケーションの種類に応じて、これを別の方法で解決できます。
+
+## シングルページアプリケーション {#single-page-applications}
+
+SSR（Server Side Rendering）を行っていない場合、`app.use(pinia)` を使用して pinia プラグインをインストールした後の `useStore()` の呼び出しは機能します:
+
+```js
+import { useUserStore } from '@/stores/user'
+import { createApp } from 'vue'
+import App from './App.vue'
+
+// ❌  fails because it's called before the pinia is created
+const userStore = useUserStore()
+
+const pinia = createPinia()
+const app = createApp(App)
+app.use(pinia)
+
+// ✅ works because the pinia instance is now active
+const userStore = useUserStore()
+```
+
+これが常に適用されるようにする最も簡単な方法は、pinia のインストール後に常に実行される関数内に `useStore()` を配置して、呼び出しを _遅延_ させることです。
+
+Vue Router でナビゲーションガード内のストアを使用する例を見てみましょう:
+
+```js
+import { createRouter } from 'vue-router'
+const router = createRouter({
+  // ...
+})
+
+// ❌ Depending on the order of imports this will fail
+const store = useStore()
+
+router.beforeEach((to, from, next) => {
+  // we wanted to use the store here
+  if (store.isLoggedIn) next()
+  else next('/login')
+})
+
+router.beforeEach((to) => {
+  // ✅ This will work because the router starts its navigation after
+  // the router is installed and pinia will be installed too
+  const store = useStore()
+
+  if (to.meta.requiresAuth && !store.isLoggedIn) return '/login'
+})
+```
+
+## SSR アプリ {#ssr-apps}
+
+Server Side Rendering を扱う場合、`useStore()` に `pinia` インスタンスを渡す必要があります。これにより、pinia が異なるアプリケーションのインスタンス間でグローバルなステートを共有することを防ぎます。
+
+[SSR ガイド](/ja/ssr/index.md) に専用のセクションがあるので、ここでは簡単に説明します:

--- a/packages/docs/ja/core-concepts/plugins.md
+++ b/packages/docs/ja/core-concepts/plugins.md
@@ -1,0 +1,413 @@
+# Plugins
+
+Pinia stores can be fully extended thanks to a low level API. Here is a list of things you can do:
+
+- Add new properties to stores
+- Add new options when defining stores
+- Add new methods to stores
+- Wrap existing methods
+- Change or even cancel actions
+- Implement side effects like [Local Storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+- Apply **only** to specific stores
+
+Plugins are added to the pinia instance with `pinia.use()`. The simplest example is adding a static property to all stores by returning an object:
+
+```js
+import { createPinia } from 'pinia'
+
+// add a property named `secret` to every store that is created after this plugin is installed
+// this could be in a different file
+function SecretPiniaPlugin() {
+  return { secret: 'the cake is a lie' }
+}
+
+const pinia = createPinia()
+// give the plugin to pinia
+pinia.use(SecretPiniaPlugin)
+
+// in another file
+const store = useStore()
+store.secret // 'the cake is a lie'
+```
+
+This is useful to add global objects like the router, modal, or toast managers.
+
+## Introduction
+
+A Pinia plugin is a function that optionally returns properties to be added to a store. It takes one optional argument, a _context_:
+
+```js
+export function myPiniaPlugin(context) {
+  context.pinia // the pinia created with `createPinia()`
+  context.app // the current app created with `createApp()` (Vue 3 only)
+  context.store // the store the plugin is augmenting
+  context.options // the options object defining the store passed to `defineStore()`
+  // ...
+}
+```
+
+This function is then passed to `pinia` with `pinia.use()`:
+
+```js
+pinia.use(myPiniaPlugin)
+```
+
+Plugins are only applied to stores created **after the plugins themselves, and after `pinia` is passed to the app**, otherwise they won't be applied.
+
+## Augmenting a Store
+
+You can add properties to every store by simply returning an object of them in a plugin:
+
+```js
+pinia.use(() => ({ hello: 'world' }))
+```
+
+You can also set the property directly on the `store` but **if possible use the return version so they can be automatically tracked by devtools**:
+
+```js
+pinia.use(({ store }) => {
+  store.hello = 'world'
+})
+```
+
+Any property _returned_ by a plugin will be automatically tracked by devtools so in order to make `hello` visible in devtools, make sure to add it to `store._customProperties` **in dev mode only** if you want to debug it in devtools:
+
+```js
+// from the example above
+pinia.use(({ store }) => {
+  store.hello = 'world'
+  // make sure your bundler handle this. webpack and vite should do it by default
+  if (process.env.NODE_ENV === 'development') {
+    // add any keys you set on the store
+    store._customProperties.add('hello')
+  }
+})
+```
+
+Note that every store is wrapped with [`reactive`](https://v3.vuejs.org/api/basic-reactivity.html#reactive), automatically unwrapping any Ref (`ref()`, `computed()`, ...) it contains:
+
+```js
+const sharedRef = ref('shared')
+pinia.use(({ store }) => {
+  // each store has its individual `hello` property
+  store.hello = ref('secret')
+  // it gets automatically unwrapped
+  store.hello // 'secret'
+
+  // all stores are sharing the value `shared` property
+  store.shared = sharedRef
+  store.shared // 'shared'
+})
+```
+
+This is why you can access all computed properties without `.value` and why they are reactive.
+
+### Adding new state
+
+If you want to add new state properties to a store or properties that are meant to be used during hydration, **you will have to add it in two places**:
+
+- On the `store` so you can access it with `store.myState`
+- On `store.$state` so it can be used in devtools and, **be serialized during SSR**.
+
+On top of that, you will certainly have to use a `ref()` (or other reactive API) in order to share the value across different accesses:
+
+```js
+import { toRef, ref } from 'vue'
+
+pinia.use(({ store }) => {
+  // to correctly handle SSR, we need to make sure we are not overriding an
+  // existing value
+  if (!Object.prototype.hasOwnProperty(store.$state, 'hasError')) {
+    // hasError is defined within the plugin, so each store has their individual
+    // state property
+    const hasError = ref(false)
+    // setting the variable on `$state`, allows it be serialized during SSR
+    store.$state.hasError = hasError
+  }
+  // we need to transfer the ref from the state to the store, this way
+  // both accesses: store.hasError and store.$state.hasError will work
+  // and share the same variable
+  // See https://vuejs.org/api/reactivity-utilities.html#toref
+  store.hasError = toRef(store.$state, 'hasError')
+
+  // in this case it's better not to return `hasError` since it
+  // will be displayed in the `state` section in the devtools
+  // anyway and if we return it, devtools will display it twice.
+})
+```
+
+Note that state changes or additions that occur within a plugin (that includes calling `store.$patch()`) happen before the store is active and therefore **do not trigger any subscriptions**.
+
+:::warning
+If you are using **Vue 2**, Pinia is subject to the [same reactivity caveats](https://v2.vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats) as Vue. You will need to use `Vue.set()` (Vue 2.7) or `set()` (from `@vue/composition-api` for Vue <2.7) for when creating new state properties like `secret` and `hasError`:
+
+```js
+import { set, toRef } from '@vue/composition-api'
+pinia.use(({ store }) => {
+  if (!Object.prototype.hasOwnProperty(store.$state, 'hello')) {
+    const secretRef = ref('secret')
+    // If the data is meant to be used during SSR, you should
+    // set it on the `$state` property so it is serialized and
+    // picked up during hydration
+    set(store.$state, 'secret', secretRef)
+  }
+  // set it directly on the store too so you can access it
+  // both ways: `store.$state.secret` / `store.secret`
+  set(store, 'secret', toRef(store.$state, 'secret'))
+  store.secret // 'secret'
+})
+```
+
+:::
+
+## Adding new external properties
+
+When adding external properties, class instances that come from other libraries, or simply things that are not reactive, you should wrap the object with `markRaw()` before passing it to pinia. Here is an example adding the router to every store:
+
+```js
+import { markRaw } from 'vue'
+// adapt this based on where your router is
+import { router } from './router'
+
+pinia.use(({ store }) => {
+  store.router = markRaw(router)
+})
+```
+
+## Calling `$subscribe` inside plugins
+
+You can use [store.$subscribe](./state.md#subscribing-to-the-state) and [store.$onAction](./actions.md#subscribing-to-actions) inside plugins too:
+
+```ts
+pinia.use(({ store }) => {
+  store.$subscribe(() => {
+    // react to store changes
+  })
+  store.$onAction(() => {
+    // react to store actions
+  })
+})
+```
+
+## Adding new options
+
+It is possible to create new options when defining stores to later on consume them from plugins. For example, you could create a `debounce` option that allows you to debounce any action:
+
+```js
+defineStore('search', {
+  actions: {
+    searchContacts() {
+      // ...
+    },
+  },
+
+  // this will be read by a plugin later on
+  debounce: {
+    // debounce the action searchContacts by 300ms
+    searchContacts: 300,
+  },
+})
+```
+
+The plugin can then read that option to wrap actions and replace the original ones:
+
+```js
+// use any debounce library
+import debounce from 'lodash/debounce'
+
+pinia.use(({ options, store }) => {
+  if (options.debounce) {
+    // we are overriding the actions with new ones
+    return Object.keys(options.debounce).reduce((debouncedActions, action) => {
+      debouncedActions[action] = debounce(
+        store[action],
+        options.debounce[action]
+      )
+      return debouncedActions
+    }, {})
+  }
+})
+```
+
+Note that custom options are passed as the 3rd argument when using the setup syntax:
+
+```js
+defineStore(
+  'search',
+  () => {
+    // ...
+  },
+  {
+    // this will be read by a plugin later on
+    debounce: {
+      // debounce the action searchContacts by 300ms
+      searchContacts: 300,
+    },
+  }
+)
+```
+
+## TypeScript
+
+Everything shown above can be done with typing support, so you don't ever need to use `any` or `@ts-ignore`.
+
+### Typing plugins
+
+A Pinia plugin can be typed as follows:
+
+```ts
+import { PiniaPluginContext } from 'pinia'
+
+export function myPiniaPlugin(context: PiniaPluginContext) {
+  // ...
+}
+```
+
+### Typing new store properties
+
+When adding new properties to stores, you should also extend the `PiniaCustomProperties` interface.
+
+```ts
+import 'pinia'
+
+declare module 'pinia' {
+  export interface PiniaCustomProperties {
+    // by using a setter we can allow both strings and refs
+    set hello(value: string | Ref<string>)
+    get hello(): string
+
+    // you can define simpler values too
+    simpleNumber: number
+  }
+}
+```
+
+It can then be written and read safely:
+
+```ts
+pinia.use(({ store }) => {
+  store.hello = 'Hola'
+  store.hello = ref('Hola')
+
+  store.simpleNumber = Math.random()
+  // @ts-expect-error: we haven't typed this correctly
+  store.simpleNumber = ref(Math.random())
+})
+```
+
+`PiniaCustomProperties` is a generic type that allows you to reference properties of a store. Imagine the following example where we copy over the initial options as `$options` (this would only work for option stores):
+
+```ts
+pinia.use(({ options }) => ({ $options: options }))
+```
+
+We can properly type this by using the 4 generic types of `PiniaCustomProperties`:
+
+```ts
+import 'pinia'
+
+declare module 'pinia' {
+  export interface PiniaCustomProperties<Id, S, G, A> {
+    $options: {
+      id: Id
+      state?: () => S
+      getters?: G
+      actions?: A
+    }
+  }
+}
+```
+
+:::tip
+When extending types in generics, they must be named **exactly as in the source code**. `Id` cannot be named `id` or `I`, and `S` cannot be named `State`. Here is what every letter stands for:
+
+- S: State
+- G: Getters
+- A: Actions
+- SS: Setup Store / Store
+
+:::
+
+### Typing new state
+
+When adding new state properties (to both, the `store` and `store.$state`), you need to add the type to `PiniaCustomStateProperties` instead. Differently from `PiniaCustomProperties`, it only receives the `State` generic:
+
+```ts
+import 'pinia'
+
+declare module 'pinia' {
+  export interface PiniaCustomStateProperties<S> {
+    hello: string
+  }
+}
+```
+
+### Typing new creation options
+
+When creating new options for `defineStore()`, you should extend the `DefineStoreOptionsBase`. Differently from `PiniaCustomProperties`, it only exposes two generics: the State and the Store type, allowing you to limit what can be defined. For example, you can use the names of the actions:
+
+```ts
+import 'pinia'
+
+declare module 'pinia' {
+  export interface DefineStoreOptionsBase<S, Store> {
+    // allow defining a number of ms for any of the actions
+    debounce?: Partial<Record<keyof StoreActions<Store>, number>>
+  }
+}
+```
+
+:::tip
+There is also a `StoreGetters` type to extract the _getters_ from a Store type. You can also extend the options of _setup stores_ or _option stores_ **only** by extending the types `DefineStoreOptions` and `DefineSetupStoreOptions` respectively.
+:::
+
+## Nuxt.js
+
+When [using pinia alongside Nuxt](../ssr/nuxt.md), you will have to create a [Nuxt plugin](https://nuxtjs.org/docs/2.x/directory-structure/plugins) first. This will give you access to the `pinia` instance:
+
+```ts
+// plugins/myPiniaPlugin.ts
+import { PiniaPluginContext } from 'pinia'
+
+function MyPiniaPlugin({ store }: PiniaPluginContext) {
+  store.$subscribe((mutation) => {
+    // react to store changes
+    console.log(`[🍍 ${mutation.storeId}]: ${mutation.type}.`)
+  })
+
+  // Note this has to be typed if you are using TS
+  return { creationTime: new Date() }
+}
+
+export default defineNuxtPlugin(({ $pinia }) => {
+  $pinia.use(MyPiniaPlugin)
+})
+```
+
+Note the above example is using TypeScript, you have to remove the type annotations `PiniaPluginContext` and `Plugin` as well as their imports if you are using a `.js` file.
+
+### Nuxt.js 2
+
+If you are using Nuxt.js 2, the types are slightly different:
+
+```ts
+// plugins/myPiniaPlugin.ts
+import { PiniaPluginContext } from 'pinia'
+import { Plugin } from '@nuxt/types'
+
+function MyPiniaPlugin({ store }: PiniaPluginContext) {
+  store.$subscribe((mutation) => {
+    // react to store changes
+    console.log(`[🍍 ${mutation.storeId}]: ${mutation.type}.`)
+  })
+
+  // Note this has to be typed if you are using TS
+  return { creationTime: new Date() }
+}
+
+const myPlugin: Plugin = ({ $pinia }) => {
+  $pinia.use(MyPiniaPlugin)
+}
+
+export default myPlugin
+```

--- a/packages/docs/ja/core-concepts/state.md
+++ b/packages/docs/ja/core-concepts/state.md
@@ -1,0 +1,263 @@
+# ステート {#state}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/access-state-from-a-pinia-store"
+  title="Learn all about state in Pinia"
+/>
+
+ステートは、ほとんどの場合、ストアの中心的な部分です。多くの場合、アプリを表すステートを定義することから始めます。Pinia では、ステートは初期状態を返す関数として定義されます。これにより、Pinia はサーバーサイドとクライアントサイドの両方で動作することができます。
+
+```js
+import { defineStore } from 'pinia'
+
+export const useStore = defineStore('storeId', {
+  // arrow function recommended for full type inference
+  state: () => {
+    return {
+      // all these properties will have their type inferred automatically
+      count: 0,
+      name: 'Eduardo',
+      isAdmin: true,
+      items: [],
+      hasChanged: true,
+    }
+  },
+})
+```
+
+:::tip
+Vue 2 を使用している場合、`state` で作成したデータは Vue インスタンスの `data` と同じルールに従います。つまり、ステートオブジェクトはプレーンでなければならず、プロパティを **新規に追加** する場合は `Vue.set()` を呼び出す必要があります。**See also: [Vue#data](https://jp.vuejs.org/v2/api/#data)**。
+:::
+
+## TypeScript {#typescript}
+
+状態を TS と互換性を持たせるために多くのことを行う必要はありません: [`strict`](https://www.typescriptlang.org/ja/tsconfig#strict)、または少なくとも [`noImplicitThis`](https://www.typescriptlang.org/ja/tsconfig#noImplicitThis) が有効になっていることを確認してください。Pinia はステートの型を自動的に推測します！ただし、多少のキャスティングを行う必要がある場合がいくつかあります:
+
+```ts
+export const useUserStore = defineStore('user', {
+  state: () => {
+    return {
+      // for initially empty lists
+      userList: [] as UserInfo[],
+      // for data that is not yet loaded
+      user: null as UserInfo | null,
+    }
+  },
+})
+
+interface UserInfo {
+  name: string
+  age: number
+}
+```
+
+必要に応じて、インターフェースでステートを定義し、`state()` の戻り値の型にできます:
+
+```ts
+interface State {
+  userList: UserInfo[]
+  user: UserInfo | null
+}
+
+export const useUserStore = defineStore('user', {
+  state: (): State => {
+    return {
+      userList: [],
+      user: null,
+    }
+  },
+})
+
+interface UserInfo {
+  name: string
+  age: number
+}
+```
+
+## ステートへのアクセス {#accessing-the-state}
+
+デフォルトでは、`store` インスタンスを通じてアクセスすることで、ステートに直接読み書きすることができます:
+
+```js
+const store = useStore()
+
+store.count++
+```
+
+**`state()` で定義していない場合**、新しいステートプロパティを追加できないことに注意してください。初期状態が含まれている必要があります。例: `state()` で `secondCount` が定義されていない場合、`store.secondCount = 2` は実行できません。
+
+## ステートのリセット {#resetting-the-state}
+
+ストアの `$reset()` メソッドを呼び出すことで、ステートを初期値に _リセット_ できます:
+
+```js
+const store = useStore()
+
+store.$reset()
+```
+
+### Options API での使用方法 {#usage-with-the-options-api}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/access-pinia-state-in-the-options-api"
+  title="Access Pinia State via the Options API"
+/>
+
+以下の例では、以下のストアが作成されたと仮定しています:
+
+```js
+// Example File Path:
+// ./src/stores/counter.js
+
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0,
+  }),
+})
+```
+
+Composition API を使用せず、`computed`、`methods`、 ...、 を使用している場合、 `mapState()` ヘルパーを使用し、ステートのプロパティを読み取り専用の computed プロパティとしてマッピングすることができます:
+
+```js
+import { mapState } from 'pinia'
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  computed: {
+    // gives access to this.count inside the component
+    // same as reading from store.count
+    ...mapState(useCounterStore, ['count'])
+    // same as above but registers it as this.myOwnName
+    ...mapState(useCounterStore, {
+      myOwnName: 'count',
+      // you can also write a function that gets access to the store
+      double: store => store.count * 2,
+      // it can have access to `this` but it won't be typed correctly...
+      magicValue(store) {
+        return store.someGetter + this.count + this.double
+      },
+    }),
+  },
+}
+```
+
+#### 変更可能なステート {#modifiable-state}
+
+これらのステートのプロパティに書き込みを行いたい場合（例えばフォームを使用している場合）は、代わりに `mapWritableState()` を使用します。`mapState()` のように関数を渡すことはできないことに注意しましょう:
+
+```js
+import { mapWritableState } from 'pinia'
+import { useCounterStore } from '../stores/counter'
+
+export default {
+  computed: {
+    // gives access to this.count inside the component and allows setting it
+    // this.count++
+    // same as reading from store.count
+    ...mapWritableState(useCounterStore, ['count'])
+    // same as above but registers it as this.myOwnName
+    ...mapWritableState(useCounterStore, {
+      myOwnName: 'count',
+    }),
+  },
+}
+```
+
+:::tip
+配列全体を `cartItems = []` に置き換えない限り、配列のようなコレクションに `mapWritableState()` は必要ありません。`mapState()` を使用すると、コレクションでメソッドを呼び出すことができます。
+:::
+
+## ステートの変異（Mutating） {#mutating-the-state}
+
+<!-- TODO: disable this with `strictMode` -->
+
+`store.count++` でストアを直接変異させる以外に、`$patch` メソッドを呼び出すこともできます。これによって、部分的な `state` オブジェクトで複数の変更を同時に適用することができます:
+
+```js
+store.$patch({
+  count: store.count + 1,
+  age: 120,
+  name: 'DIO',
+})
+```
+
+ただし、一部の変異は、この構文で適用するのが非常に困難、またはコストがかかります: コレクションの変更（配列からの要素のプッシュ、削除、スプライシングなど）では、新しいコレクションを作成する必要があります。このため、`$patch` メソッドは、パッチオブジェクトで適用するのが難しいこの種の変異をグループ化する関数も受け入れます:
+
+```js
+store.$patch((state) => {
+  state.items.push({ name: 'shoes', quantity: 1 })
+  state.hasChanged = true
+})
+```
+
+<!-- TODO: disable this with `strictMode`, `{ noDirectPatch: true }` -->
+
+ここでの主な違いは、`$patch()` によって、複数の変更をまとめて devtools の 1 つのエントリにすることができることです。**`state` への直接の変更と `$patch()` の両方が devtools に表示され**、タイムトラベルができることに注意してください（Vue 3 ではまだありません）。
+
+## ステートのリプレイス {#replacing-the-state}
+
+リアクティビティが損なわれるため、ストアの状態を **正しく置き換えることはできません**。しかし、_パッチする_ ことはできます:
+
+```js
+// this doesn't actually replace `$state`
+store.$state = { count: 24 }
+// it internally calls `$patch()`:
+store.$patch({ count: 24 })
+```
+
+また、`pinia` インスタンスの `state` を変更することで、アプリケーション全体の **初期状態を設定** することができます。これは [SSR 時のハイドレーション](../ssr/#state-hydration) に使用されます。
+
+```js
+pinia.state.value = {}
+```
+
+## ステートの購読（Subscribing） {#subscribing-to-the-state}
+
+Vuex の [subscribe メソッド](https://vuex.vuejs.org/ja/api/#subscribe) と同様に、ストアの `$subscribe()` メソッドを通じて、ステートとその変更を監視することができます。通常の `watch()` よりも `$subscribe()` を使う利点は、_サブスクリプション_ が _パッチ_ の後に一度だけ起動することです（例: 上記の関数版を使用した場合）。
+
+```js
+cartStore.$subscribe((mutation, state) => {
+  // import { MutationType } from 'pinia'
+  mutation.type // 'direct' | 'patch object' | 'patch function'
+  // same as cartStore.$id
+  mutation.storeId // 'cart'
+  // only available with mutation.type === 'patch object'
+  mutation.payload // patch object passed to cartStore.$patch()
+
+  // persist the whole state to the local storage whenever it changes
+  localStorage.setItem('cart', JSON.stringify(state))
+})
+```
+
+デフォルトでは、_ステートのサブスクリプション_ は、それらが追加されたコンポーネントにバインドされます（ストアがコンポーネントの `setup()` 内にある場合）。つまり、コンポーネントがアンマウントされると、自動的に削除されます。コンポーネントがアンマウントされた後もそれらを保持したい場合、第 2 引数として `{ detached: true }` を渡して、現在のコンポーネントから _ステートのサブスクリプション_ を _切り離し_ ます:
+
+```js
+export default {
+  setup() {
+    const someStore = useSomeStore()
+
+    // this subscription will be kept even after the component is unmounted
+    someStore.$subscribe(callback, { detached: true })
+
+    // ...
+  },
+}
+```
+
+:::tip
+`pinia` インスタンスで、ステート全体を監視することができます:
+
+```js
+watch(
+  pinia.state,
+  (state) => {
+    // persist the whole state to the local storage whenever it changes
+    localStorage.setItem('piniaState', JSON.stringify(state))
+  },
+  { deep: true }
+)
+```
+
+:::

--- a/packages/docs/ja/getting-started.md
+++ b/packages/docs/ja/getting-started.md
@@ -1,0 +1,64 @@
+## インストール {#installation}
+
+<VueMasteryLogoLink for="pinia-cheat-sheet">
+</VueMasteryLogoLink>
+
+お好みのパッケージマネージャで `pinia` をインストールします:
+
+```bash
+yarn add pinia
+# or with npm
+npm install pinia
+```
+
+:::tip
+Vue <2.7 を使用している場合、composition api: `@vue/composition-api` もインストールする必要があります。Nuxt を使用している場合、[こちらの手順](./ssr/nuxt.md) に従ってください。
+:::
+
+Vue CLI を使用している場合、代わりにこちらの [**非公式プラグイン**](https://github.com/wobsoriano/vue-cli-plugin-pinia) を試してみてください。
+
+pinia インスタンス（ルートストア）を作成し、プラグインとしてアプリに渡します:
+
+```js {2,5-6,8}
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+
+const pinia = createPinia()
+const app = createApp(App)
+
+app.use(pinia)
+app.mount('#app')
+```
+
+Vue 2 を使用している場合、プラグインをインストールし、作成した `pinia` をアプリのルートにインジェクトする必要があります:
+
+```js {1,3-4,12}
+import { createPinia, PiniaVuePlugin } from 'pinia'
+
+Vue.use(PiniaVuePlugin)
+const pinia = createPinia()
+
+new Vue({
+  el: '#app',
+  // other options...
+  // ...
+  // note the same `pinia` instance can be used across multiple Vue apps on
+  // the same page
+  pinia,
+})
+```
+
+これにより devtools のサポートも追加されます。Vue 3 では、vue-devtools が必要な API をまだ公開していないため、タイムトラベルや編集などの一部の機能はまだサポートされていませんが、devtools ははるかに多くの機能を持ち、全体としての開発者体験ははるかに優れています。Vue 2 では、Pinia は Vuex の既存のインターフェースを使用します（したがって Vuex と一緒に使用することはできません）。
+
+## Store とは？ {#what-is-a-store}
+
+ストア（Pinia など）は、コンポーネントツリーにバインドされていない、状態とビジネスロジックを保持するエンティティです。つまり、**グローバルな状態を保持** します。ストアは常に存在し、誰もが読み書きできるコンポーネントのようなものです。[state](./core-concepts/state.md)、[getters](./core-concepts/getters.md) そして [actions](./core-concepts/actions.md) という **3つの概念** を持ち、これらの概念は、コンポーネントにおける `data`、`computed` そして `methods` に相当すると考えてよいでしょう。
+
+## どのような場合に Store を使用するか {#when-should-i-use-a-store}
+
+ストアには、アプリケーション全体を通してアクセスできるデータを格納する必要があります。これには、例えばナビゲーションバーに表示されるユーザー情報のように多くの場所で使用されるデータや、非常に複雑なマルチステップフォームのようにページを通して保存する必要があるデータも含まれます。
+
+一方、代わりにコンポーネントで保持される可能性のあるローカルデータをストアに含めることは避ける必要があります。例: ページに固有な要素の可視性。
+
+すべてのアプリケーションがグローバルな状態へのアクセスを必要とするわけではありませんが、もし必要であれば、Pinia はあなたの生活をより快適なものにしてくれることでしょう。

--- a/packages/docs/ja/index.md
+++ b/packages/docs/ja/index.md
@@ -1,0 +1,37 @@
+---
+home: true
+heroImage: /logo.svg
+actionText: Get Started
+actionLink: /ja/introduction.html
+
+altActionText: Demo
+altActionLink: https://stackblitz.com/github/piniajs/example-vue-3-vite
+
+features:
+  - title: 💡 Intuitive
+    details: Stores are as familiar as components. API designed to let you write well organized stores.
+  - title: 🔑 Type Safe
+    details: Types are inferred, which means stores provide you with autocompletion even in JavaScript!
+  - title: ⚙️ Devtools support
+    details: Pinia hooks into Vue devtools to give you an enhanced development experience in both Vue 2 and Vue 3.
+  - title: 🔌 Extensible
+    details: React to store changes to extend Pinia with transactions, local storage synchronization, etc.
+  - title: 🏗 Modular by design
+    details: Build multiple stores and let your bundler code split them automatically.
+  - title: 📦 Extremely light
+    details: Pinia weighs ~1.5kb, you will forget it's even there!
+footer: MIT Licensed | Copyright © 2019-present Eduardo San Martin Morote
+---
+
+<ClientOnly>
+  <ThemeToggle/>
+  <!-- <TestStore/> -->
+</ClientOnly>
+
+<HomeSponsors />
+
+<script setup>
+import HomeSponsors from '../.vitepress/components/HomeSponsors.vue'
+import ThemeToggle from '../.vitepress/components/ThemeToggle.vue'
+// import TestStore from '../.vitepress/components/TestStore.vue'
+</script>

--- a/packages/docs/ja/introduction.md
+++ b/packages/docs/ja/introduction.md
@@ -1,0 +1,195 @@
+# はじめに {#introduction}
+
+<VueSchoolLink
+  href="https://vueschool.io/lessons/introduction-to-pinia"
+  title="Get started with Pinia"
+/>
+
+Pinia は、2019 年 11 月頃 [Composition API](https://github.com/vuejs/composition-api) を使って Vue 用の Store がどのようなものになるかを再設計する実験として [始まりました](https://github.com/vuejs/pinia/commit/06aeef54e2cad66696063c62829dac74e15fd19e)。それ以来、最初の原則は変わっていませんが、Pinia は Vue 2 と Vue 3 の両方で動作し、**composition API を使用する必要はありません**。API は _インストール_ と _SSR_ 以外はどちらも同じで、このドキュメントは Vue 3 を対象として、必要なときに **Vue 2** に関する注釈を入れているので、Vue 2 と Vue 3 のユーザーにも読んでもらえると思います。
+
+## なぜ Pinia を使うべきなのか？ {#why-should-i-use-pinia}
+
+Pinia は Vue のためのストアライブラリで、コンポーネントやページ間で状態を共有することができます。Composition API に慣れていると、単純な `export const state = reactive({})` ですでにグローバルなステートを共有できると思うかもしれません。これは単一ページのアプリケーションには当てはまりますが、サーバーサイドでレンダリングする場合、**アプリケーションは [セキュリティの脆弱性](https://ja.vuejs.org/guide/scaling-up/ssr.html#cross-request-state-pollution) にさらされます**。しかし、小さな単一ページのアプリケーションであっても、Pinia を使用することで多くのことを得ることができます。
+
+- Devtools のサポート
+  - アクション、ミューテーションを追跡するためのタイムライン
+  - 使用されるコンポーネントにストアが表示される
+  - タイムトラベルと容易なデバッグ
+- Hot module replacement
+  - ページを再読み込みすることなくストアを変更
+  - 既存の状態を維持したまま開発可能
+- プラグイン: プラグインによる Pinia の機能拡張
+- 適切な TypeScript サポート、または JS ユーザーのための **オートコンプリート**
+- サーバーサイドレンダリング対応
+
+<VueMasteryLogoLink for="pinia-cheat-sheet">
+</VueMasteryLogoLink>
+
+## 基本的な例 {#basic-example}
+
+Pinia の使い方を API で説明します（完全な説明は [Getting Started](./getting-started.md) を確認してください）。まず、ストアを作成します:
+
+```js
+// stores/counter.js
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', {
+  state: () => {
+    return { count: 0 }
+  },
+  // could also be defined as
+  // state: () => ({ count: 0 })
+  actions: {
+    increment() {
+      this.count++
+    },
+  },
+})
+```
+
+そして、それをコンポーネントで _使用_ します:
+
+```js
+import { useCounterStore } from '@/stores/counter'
+
+export default {
+  setup() {
+    const counter = useCounterStore()
+
+    counter.count++
+    // with autocompletion ✨
+    counter.$patch({ count: counter.count + 1 })
+    // or using an action instead
+    counter.increment()
+  },
+}
+```
+
+より高度なユースケースのために、関数（コンポーネントの `setup()` と同様）を使って Store を定義することも可能です:
+
+```js
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0)
+  function increment() {
+    count.value++
+  }
+
+  return { count, increment }
+})
+```
+
+もしまだ `setup()` や Composition API に慣れていない場合でも、心配する必要はありません。Pinia も [Vuex のようなマップヘルパー](https://vuex.vuejs.org/guide/state.html#the-mapstate-helper) をサポートしています。ストアの定義は同じですが、`mapStores()`、`mapState()`、または `mapActions()` を使用します:
+
+```js {22,24,28}
+const useCounterStore = defineStore('counter', {
+  state: () => ({ count: 0 }),
+  getters: {
+    double: (state) => state.count * 2,
+  },
+  actions: {
+    increment() {
+      this.count++
+    },
+  },
+})
+
+const useUserStore = defineStore('user', {
+  // ...
+})
+
+export default {
+  computed: {
+    // other computed properties
+    // ...
+    // gives access to this.counterStore and this.userStore
+    ...mapStores(useCounterStore, useUserStore),
+    // gives read access to this.count and this.double
+    ...mapState(useCounterStore, ['count', 'double']),
+  },
+  methods: {
+    // gives access to this.increment()
+    ...mapActions(useCounterStore, ['increment']),
+  },
+}
+```
+
+各 _マップヘルパー_ の詳細については、コアコンセプトをご覧ください。
+
+## なぜ _Pinia_ なのか {#why-pinia}
+
+Pinia (発音は `/piːnjʌ/`、英語では "peenya") は、パッケージ名として有効な _piña_ (スペイン語で _パイナップル_) に最も近い単語です。パイナップルは、実は一つ一つの花が集まって、複数の果実を作っています。Store と同じで、ひとつひとつは個々に生まれますが、最後にはすべてつながっています。また、南米原産のおいしいトロピカルフルーツです。
+
+## より現実的な例 {#a-more-realistic-example}
+
+以下は **JavaScriptでも型を使用した** Pinia で使用する API のより完全な例です。人によっては、これ以上読まずに始めるには十分かもしれませんが、他のドキュメントをチェックしたり、この例を読み飛ばして _コアコンセプト_ のすべてを読んでから戻ってくることをお勧めします。
+
+```js
+import { defineStore } from 'pinia'
+
+export const useTodos = defineStore('todos', {
+  state: () => ({
+    /** @type {{ text: string, id: number, isFinished: boolean }[]} */
+    todos: [],
+    /** @type {'all' | 'finished' | 'unfinished'} */
+    filter: 'all',
+    // type will be automatically inferred to number
+    nextId: 0,
+  }),
+  getters: {
+    finishedTodos(state) {
+      // autocompletion! ✨
+      return state.todos.filter((todo) => todo.isFinished)
+    },
+    unfinishedTodos(state) {
+      return state.todos.filter((todo) => !todo.isFinished)
+    },
+    /**
+     * @returns {{ text: string, id: number, isFinished: boolean }[]}
+     */
+    filteredTodos(state) {
+      if (this.filter === 'finished') {
+        // call other getters with autocompletion ✨
+        return this.finishedTodos
+      } else if (this.filter === 'unfinished') {
+        return this.unfinishedTodos
+      }
+      return this.todos
+    },
+  },
+  actions: {
+    // any amount of arguments, return a promise or not
+    addTodo(text) {
+      // you can directly mutate the state
+      this.todos.push({ text, id: this.nextId++, isFinished: false })
+    },
+  },
+})
+```
+
+## Vuex との比較 {#comparison-with-vuex}
+
+Pinia は Vuex の次のイテレーションがどのようなものかを探るために始まり、Vuex 5 のコアチームの議論から多くのアイデアを取り込みました。最終的に、Pinia は Vuex 5 で私たちが望んでいたことのほとんどをすでに実装していることに気づき、代わりにこれを新しい推奨とすることにしました。
+
+Vuex と比較して、Pinia は控えめでシンプルな API を提供し、Composition-API-style の API を提供し、そして最も重要なことは TypeScript で使用した場合に確実な型推論をサポートすることです。
+
+### RFCs {#rfcs}
+
+当初、Pinia は RFC のプロセスを経ていませんでした。私は、アプリケーションを開発した経験、他の人のコードを読んだ経験、Pinia を使うクライアントのために働いた経験、Discord で質問に答えた経験に基づいて、アイデアをテストしました。
+これにより、様々なケースやアプリケーションのサイズに適応し、機能するソリューションを提供することができました。私は頻繁にパブリッシュを行い、ライブラリのコア API を同じにしながら進化させるようにしました。
+
+Pinia がデフォルトの状態管理ソリューションとなった今、Vue エコシステムの他のコアライブラリと同じ RFC プロセスの対象となり、その API は安定した状態に入りました。
+
+### Vuex 3.x/4.x との比較 {#comparison-with-vuex-3-x-4-x}
+
+> Vuex 3.x は Vue 2 用の Vuex で、Vuex 4.x は Vue 3 用の Vuex です。
+
+Pinia の API は、Vuex ≤4 と大きく異なっています:
+
+- _mutations_ はもはや存在しません。それらはしばしば **非常に冗長** と認識されていました。当初、devtools の統合をもたらしましたが、それはもはや問題ではありません。
+- TypeScript をサポートするために複雑なラッパーをカスタムで作成する必要はなく、すべてが型付けされ、API は TS 型推論を可能な限り活用できるように設計されています。
+- もう魔法の文字列を注入する必要はなく、関数をインポートし、呼び出し、オートコンプリートを楽しむことができます！
+- ストアをダイナミックに追加する必要はありません。デフォルトですべてダイナミックになっているので、気づくこともないでしょう。なお、手動でストアを使用して好きなときに登録することもできますが、自動で行われるため、気にする必要はありません。
+- _モジュール_ の入れ子構造はもうやめましょう。ストアをインポートして別のストアの中で _使う_ ことで、暗黙のうちにストアを入れ子にすることはできますが、Pinia は設計上フラットな構造を提供し、ストア間のクロスコンポジションを可能にしています。 **ストアの循環依存関係を持つことさえできます**。
+- _名前空間のあるモジュール_ はありません。ストアのフラットなアーキテクチャを考えると、ストアの「名前空間」はストアの定義方法に固有のものであり、すべてのストアは名前空間であると言えるかもしれません。
+
+既存の Vuex ≤4 プロジェクトを Pinia 用に変換する詳細な手順については、[Vuex からの移行ガイド](./cookbook/migration-vuex.md) を参照してください。

--- a/packages/docs/ja/ssr/index.md
+++ b/packages/docs/ja/ssr/index.md
@@ -1,0 +1,111 @@
+# Server Side Rendering (SSR)
+
+:::tip
+If you are using **Nuxt.js,** you need to read [**these instructions**](./nuxt.md) instead.
+:::
+
+Creating stores with Pinia should work out of the box for SSR as long as you call your `useStore()` functions at the top of `setup` functions, `getters` and `actions`:
+
+```js
+export default defineComponent({
+  setup() {
+    // this works because pinia knows what application is running inside of
+    // `setup()`
+    const main = useMainStore()
+    return { main }
+  },
+})
+```
+
+## Using the store outside of `setup()`
+
+If you need to use the store somewhere else, you need to pass the `pinia` instance [that was passed to the app](#install-the-plugin) to the `useStore()` function call:
+
+```js
+const pinia = createPinia()
+const app = createApp(App)
+
+app.use(router)
+app.use(pinia)
+
+router.beforeEach((to) => {
+  // ✅ This will work make sure the correct store is used for the
+  // current running app
+  const main = useMainStore(pinia)
+
+  if (to.meta.requiresAuth && !main.isLoggedIn) return '/login'
+})
+```
+
+Pinia conveniently adds itself as `$pinia` to your app so you can use it in functions like `serverPrefetch()`:
+
+```js
+export default {
+  serverPrefetch() {
+    const store = useStore(this.$pinia)
+  },
+}
+```
+
+## State hydration
+
+To hydrate the initial state, you need to make sure the rootState is included somewhere in the HTML for Pinia to pick it up later on. Depending on what you are using for SSR, **you should escape the state for security reasons**. We recommend using [@nuxt/devalue](https://github.com/nuxt-contrib/devalue) which is the one used by Nuxt.js:
+
+```js
+import devalue from '@nuxt/devalue'
+import { createPinia } from 'pinia'
+// retrieve the rootState server side
+const pinia = createPinia()
+const app = createApp(App)
+app.use(router)
+app.use(pinia)
+
+// after rendering the page, the root state is built and can be read directly
+// on `pinia.state.value`.
+
+// serialize, escape (VERY important if the content of the state can be changed
+// by the user, which is almost always the case), and place it somewhere on
+// the page, for example, as a global variable.
+devalue(pinia.state.value)
+```
+
+Depending on what you are using for SSR, you will set an _initial state_ variable that will be serialized in the HTML. You should also protect yourself from XSS attacks. For example, with [vite-ssr](https://github.com/frandiox/vite-ssr) you can use the [`transformState` option](https://github.com/frandiox/vite-ssr#state-serialization) and `@nuxt/devalue`:
+
+```js
+import devalue from '@nuxt/devalue'
+
+export default viteSSR(
+  App,
+  {
+    routes,
+    transformState(state) {
+      return import.meta.env.SSR ? devalue(state) : state
+    },
+  },
+  ({ initialState }) => {
+    // ...
+    if (import.meta.env.SSR) {
+      // this will be stringified and set to window.__INITIAL_STATE__
+      initialState.pinia = pinia.state.value
+    } else {
+      // on the client side, we restore the state
+      pinia.state.value = initialState.pinia
+    }
+  }
+)
+```
+
+You can use [other alternatives](https://github.com/nuxt-contrib/devalue#see-also) to `@nuxt/devalue` depending on what you need, e.g. if you can serialize and parse your state with `JSON.stringify()`/`JSON.parse()`, **you could improve your performance by a lot**.
+
+Adapt this strategy to your environment. Make sure to hydrate pinia's state before calling any `useStore()` function on client side. For example, if we serialize the state into a `<script>` tag to make it accessible globally on client side through `window.__pinia`, we can write this:
+
+```js
+const pinia = createPinia()
+const app = createApp(App)
+app.use(pinia)
+
+// must be set by the user
+if (isClient) {
+  pinia.state.value = JSON.parse(window.__pinia)
+}
+```

--- a/packages/docs/ja/ssr/nuxt.md
+++ b/packages/docs/ja/ssr/nuxt.md
@@ -1,0 +1,130 @@
+# Nuxt.js
+
+Using Pinia with [Nuxt.js](https://nuxtjs.org/) is easier since Nuxt takes care of a lot of things when it comes to _server side rendering_. For instance, **you don't need to care about serialization nor XSS attacks**. Pinia supports Nuxt Bridge and Nuxt 3. For bare Nuxt 2 support, [see below](#nuxt-2-without-bridge).
+
+## Installation
+
+```bash
+yarn add pinia @pinia/nuxt
+# or with npm
+npm install pinia @pinia/nuxt
+```
+
+:::tip 
+If you're using npm, you might encounter an _ERESOLVE unable to resolve dependency tree_ error. In that case, add the following to your `package.json`:
+
+```js
+"overrides": { 
+  "vue": "latest"
+}
+```
+:::
+
+We supply a _module_ to handle everything for you, you only need to add it to `modules` in your `nuxt.config.js` file:
+
+```js
+// nuxt.config.js
+export default defineNuxtConfig({
+  // ... other options
+  modules: [
+    // ...
+    '@pinia/nuxt',
+  ],
+})
+```
+
+And that's it, use your store as usual!
+
+## Using the store outside of `setup()`
+
+If you want to use a store outside of `setup()`, remember to pass the `pinia` object to `useStore()`. We added it to [the context](https://nuxtjs.org/docs/2.x/internals-glossary/context) so you have access to it in `asyncData()` and `fetch()`:
+
+```js
+import { useStore } from '~/stores/myStore'
+
+export default {
+  asyncData({ $pinia }) {
+    const store = useStore($pinia)
+  },
+}
+```
+
+## Auto imports
+
+By default `@pinia/nuxt` exposes one single auto import: `usePinia()`, which is similar to `getActivePinia()` but works better with Nuxt. You can add auto imports to make your life easier:
+
+```js
+// nuxt.config.js
+export default defineNuxtConfig({
+  // ... other options
+  modules: [
+    // ...
+    [
+      '@pinia/nuxt',
+      {
+        autoImports: [
+          // automatically imports `defineStore`
+          'defineStore', // import { defineStore } from 'pinia'
+          // automatically imports `defineStore` as `definePiniaStore`
+          ['defineStore', 'definePiniaStore'], // import { defineStore as definePiniaStore } from 'pinia'
+        ],
+      },
+    ],
+  ],
+})
+```
+
+## Nuxt 2 without bridge
+
+Pinia supports Nuxt 2 until `@pinia/nuxt` v0.2.1. Make sure to also install [`@nuxtjs/composition-api`](https://composition-api.nuxtjs.org/) alongside `pinia`:
+
+```bash
+yarn add pinia @pinia/nuxt@0.2.1 @nuxtjs/composition-api
+# or with npm
+npm install pinia @pinia/nuxt@0.2.1 @nuxtjs/composition-api
+```
+
+We supply a _module_ to handle everything for you, you only need to add it to `buildModules` in your `nuxt.config.js` file:
+
+```js
+// nuxt.config.js
+export default {
+  // ... other options
+  buildModules: [
+    // Nuxt 2 only:
+    // https://composition-api.nuxtjs.org/getting-started/setup#quick-start
+    '@nuxtjs/composition-api/module',
+    '@pinia/nuxt',
+  ],
+}
+```
+
+### TypeScript
+
+If you are using Nuxt 2 (`@pinia/nuxt` < 0.3.0) with TypeScript or have a `jsconfig.json`, you should also add the types for `context.pinia`:
+
+```json
+{
+  "types": [
+    // ...
+    "@pinia/nuxt"
+  ]
+}
+```
+
+This will also ensure you have autocompletion 😉 .
+
+### Using Pinia alongside Vuex
+
+It is recommended to **avoid using both Pinia and Vuex** but if you need to use both, you need to tell pinia to not disable it:
+
+```js
+// nuxt.config.js
+export default {
+  buildModules: [
+    '@nuxtjs/composition-api/module',
+    ['@pinia/nuxt', { disableVuex: false }],
+  ],
+  // ... other options
+}
+```


### PR DESCRIPTION
Hello.

I have translated the guide into Japanese for my own study as well.

The target is only the pages that seem to be frequently referred to in the guide,
but it may be a starting point for future work on the Japanese translation.

I would appreciate it if you could check and merge them.