### PR TITLE
docs: link to Spanish translation

### DIFF
--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -9,5 +9,10 @@ export default defineConfig({
   locales: {
     root: { label: 'English', lang: 'en-US', link: '/', ...enConfig },
     zh: { label: '简体中文', lang: 'zh-CN', link: '/zh/', ...zhConfig },
+    es: {
+      label: 'Español',
+      lang: 'es-ES',
+      link: 'https://es-pinia.vercel.app/',
+    },
   },
 })


### PR DESCRIPTION
# Spanish docs

(Same as #1986)

Hi! :wave:  As we discussed [here](https://github.com/vuejs/pinia/discussions/1886), Pinia docs has been translated to Spanish! :tada: 

## Where will be this translation hosted?

Since Vitepress 1 allow us to add an external link in the language selector, we don't need to add all the translation files in the main repo docs and the maintenance of the translation won't influence the whole Pinia repo . 

![Spanish Integration](https://user-images.githubusercontent.com/77344353/217466781-f0f63a61-c7b0-4d27-bea6-0ac135ac565c.png)

You can see the translation [here](https://es-pinia.vercel.app/) and in [this repo](https://github.com/raulwwq0/pinia-spanish-docs) :smile: .

> ~~We want to include this with the release of the new official docs. Our currently Vitepress version is 0.22.4 but we are also working to [migrate the translation to Vitepress 1](https://github.com/raulwwq0/pinia-spanish-docs/pull/31) and we hope to finish that nearly as the same time as the official one.~~ We're also using Vitepress 1 now :partying_face: 

## Contributors

Thanks to @edgonzalez24 and @icarusgk for their amazing job helping with the translations.