### PR TITLE
docs: const name in the useMedia example

### DIFF
--- a/packages/docs/cookbook/composables.md
+++ b/packages/docs/cookbook/composables.md
@@ -38,7 +38,7 @@ export const useVideoPlayer = defineStore('video', () => {
   const videoElement = ref<HTMLVideoElement>()
   const src = ref('/data/video.mp4')
   const { playing, volume, currentTime, togglePictureInPicture } =
-    useMediaControls(video, { src })
+    useMediaControls(videoElement, { src })
 
   function loadVideo(element: HTMLVideoElement, src: string) {
     videoElement.value = element


### PR DESCRIPTION
The example code referenced a `video` variable that did exist in the example code (probably a copy-and-paste typo). The new code points to the `videoElement` const declared a few lines before.

Regarding "Please make sure to include a test! If this is closing an existing issue, reference that issue as well.", since it is a documentation update, I assume tests are not required.
