### PR TITLE
docs(zh):  Correct the code on line 11 in actions.md

### DIFF
--- a/packages/docs/zh/core-concepts/actions.md
+++ b/packages/docs/zh/core-concepts/actions.md
@@ -8,7 +8,7 @@
 Action 相当于组件中的 [method](https://v3.vuejs.org/guide/data-methods.html#methods)。它们可以通过 `defineStore()` 中的 `actions` 属性来定义，**并且它们也是定义业务逻辑的完美选择。**
 
 ```js
-export const useStore = defineStore('main', {
+export const useCounterStore = defineStore('main', {
   state: () => ({
     count: 0,
   }),


### PR DESCRIPTION
Correct the code on line 11. In the English Doc, the variable name is `useCounterStore`, but in the Chinese Doc, it was `useStore`. I change the variable name (which in the Chinese Doc) to `useCounterStore`, because this variable is used for many places in the doc, and it would confuse other readers if we don't correct it.
修正了第11行的代码（英文文档中变量名应该是useCounterStore，中文文档中写成了useStore，此处错误会影响对后面几个示例的理解，因而进行了修改）

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
