### PR TITLE
docs: import storeToRefs in example

### DIFF
--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -98,6 +98,7 @@ and use in component:
 
 ```vue
 <script setup>
+import { storeToRefs } from "pinia";
 import { useUserListStore } from './store'
 
 const userList = useUserListStore()

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -98,7 +98,7 @@ and use in component:
 
 ```vue
 <script setup>
-import { storeToRefs } from "pinia";
+import { storeToRefs } from 'pinia';
 import { useUserListStore } from './store'
 
 const userList = useUserListStore()

--- a/packages/docs/core-concepts/getters.md
+++ b/packages/docs/core-concepts/getters.md
@@ -98,7 +98,7 @@ and use in component:
 
 ```vue
 <script setup>
-import { storeToRefs } from 'pinia';
+import { storeToRefs } from 'pinia'
 import { useUserListStore } from './store'
 
 const userList = useUserListStore()


### PR DESCRIPTION
I noticed `storeToRefs` import is missing so this PR fixes that.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
