### PR TITLE
fix: allow `$reset` to be overridden by plugins

### DIFF
--- a/packages/docs/core-concepts/plugins.md
+++ b/packages/docs/core-concepts/plugins.md
@@ -160,6 +160,35 @@ pinia.use(({ store }) => {
 
 :::
 
+If you require that any state introduced by your plugin should be reset when `$reset` is called on your store, then you will need to overwrite `$reset` to include the resetting of your state:
+
+```js
+import { set, toRef } from '@vue/composition-api'
+pinia.use(({ store }) => {
+  if (!Object.prototype.hasOwnProperty(store.$state, 'hello')) {
+    const secretRef = ref('secret')
+    // If the data is meant to be used during SSR, you should
+    // set it on the `$state` property so it is serialized and
+    // picked up during hydration
+    set(store.$state, 'secret', secretRef)
+  }
+  // set it directly on the store too so you can access it
+  // both ways: `store.$state.secret` / `store.secret`
+  set(store, 'secret', toRef(store.$state, 'secret'))
+  store.secret // 'secret'
+
+  const originalReset = store.$reset.bind(store)
+  return {
+    $reset() {
+      // Reset any state defined in the store and required to be reset by other plugins.
+      originalReset()
+      // Reset state introduced by this plugin if necessary.
+      store.secret = 'secret'
+    }
+  }
+})
+```
+
 ## Adding new external properties
 
 When adding external properties, class instances that come from other libraries, or simply things that are not reactive, you should wrap the object with `markRaw()` before passing it to pinia. Here is an example adding the router to every store:

--- a/packages/pinia/__tests__/storePlugins.spec.ts
+++ b/packages/pinia/__tests__/storePlugins.spec.ts
@@ -18,6 +18,7 @@ declare module '../src' {
   export interface PiniaCustomStateProperties<S> {
     // pluginN: 'test' extends Id ? number : never | undefined
     pluginN: number
+    plugin2N: number
     shared: number
   }
 }
@@ -62,6 +63,109 @@ describe('store plugins', () => {
     store.pluginN.notExisting
     // @ts-expect-error: it should always be 'test'
     store.idFromPlugin == 'hello'
+  })
+
+  it('allows $reset to be overridden which resets plugin state and store state', () => {
+    const pinia = createPinia()
+
+    const useStore = defineStore({
+      id: 'main',
+      state: () => ({ n: 0 }),
+    })
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    // must call use after installing the plugin
+    pinia.use(({ app, store }) => {
+      if (!store.$state.hasOwnProperty('pluginN')) {
+        // @ts-expect-error: cannot be a ref yet
+        store.$state.pluginN = ref(20)
+      }
+      // @ts-expect-error: TODO: allow setting refs
+      store.pluginN = toRef(store.$state, 'pluginN')
+
+      const originalReset = store.$reset.bind(store)
+      return {
+        uid: app._uid,
+        $reset() {
+          originalReset()
+          store.pluginN = 20
+        },
+      }
+    })
+
+    const store = useStore(pinia)
+
+    store.n = 100
+    store.pluginN = 200
+
+    store.$reset()
+
+    expect(store.n).toBe(0)
+    expect(store.$state.pluginN).toBe(20)
+    expect(store.pluginN).toBe(20)
+  })
+
+  it('allows $reset to be overridden by multiple plugings which resets plugin state and store state', () => {
+    const pinia = createPinia()
+
+    const useStore = defineStore({
+      id: 'main',
+      state: () => ({ n: 0 }),
+    })
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    // must call use after installing the plugin
+    pinia
+      .use(({ app, store }) => {
+        if (!store.$state.hasOwnProperty('pluginN')) {
+          // @ts-expect-error: cannot be a ref yet
+          store.$state.pluginN = ref(20)
+        }
+        // @ts-expect-error: TODO: allow setting refs
+        store.pluginN = toRef(store.$state, 'pluginN')
+
+        const originalReset = store.$reset.bind(store)
+        return {
+          uid: app._uid,
+          $reset() {
+            originalReset()
+            store.pluginN = 20
+          },
+        }
+      })
+      .use(({ app, store }) => {
+        if (!store.$state.hasOwnProperty('plugin2N')) {
+          // @ts-expect-error: cannot be a ref yet
+          store.$state.plugin2N = ref(30)
+        }
+        // @ts-expect-error: TODO: allow setting refs
+        store.plugin2N = toRef(store.$state, 'plugin2N')
+
+        const originalReset = store.$reset.bind(store)
+        return {
+          uid: app._uid,
+          $reset() {
+            originalReset()
+            store.plugin2N = 30
+          },
+        }
+      })
+
+    const store = useStore(pinia)
+
+    store.n = 100
+    store.pluginN = 200
+    store.plugin2N = 300
+
+    store.$reset()
+
+    expect(store.n).toBe(0)
+    expect(store.$state.pluginN).toBe(20)
+    expect(store.pluginN).toBe(20)
+    expect(store.$state.plugin2N).toBe(30)
+    expect(store.plugin2N).toBe(30)
   })
 
   it('can install plugins before installing pinia', () => {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -321,7 +321,6 @@ function createSetupStore<
     )
   }
 
-  /* istanbul ignore next */
   const $reset = isOptionsStore
     ? function $reset(this: _StoreWithState<Id, S, G, A>) {
         const { state } = options as DefineStoreOptions<Id, S, G, A>
@@ -331,7 +330,8 @@ function createSetupStore<
           assign($state, newState)
         })
       }
-    : __DEV__
+    : /* istanbul ignore next */
+    __DEV__
     ? () => {
         throw new Error(
           `🍍: Store "${$id}" is built using the setup syntax and does not implement $reset().`

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -324,7 +324,7 @@ function createSetupStore<
   /* istanbul ignore next */
   const $reset = isOptionsStore
     ? function $reset(this: _StoreWithState<Id, S, G, A>) {
-        const { state } = options as any
+        const { state } = options as DefineStoreOptions<Id, S, G, A>
         const newState = state ? state() : {}
         // we use a patch to group all changes into one single subscription
         this.$patch(($state) => {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -195,14 +195,6 @@ function createOptionsStore<
 
   store = createSetupStore(id, setup, options, pinia, hot, true)
 
-  store.$reset = function $reset() {
-    const newState = state ? state() : {}
-    // we use a patch to group all changes into one single subscription
-    this.$patch(($state) => {
-      assign($state, newState)
-    })
-  }
-
   return store as any
 }
 
@@ -330,7 +322,16 @@ function createSetupStore<
   }
 
   /* istanbul ignore next */
-  const $reset = __DEV__
+  const $reset = isOptionsStore
+    ? function $reset(this: _StoreWithState<Id, S, G, A>) {
+        const { state } = options as any
+        const newState = state ? state() : {}
+        // we use a patch to group all changes into one single subscription
+        this.$patch(($state) => {
+          assign($state, newState)
+        })
+      }
+    : __DEV__
     ? () => {
         throw new Error(
           `🍍: Store "${$id}" is built using the setup syntax and does not implement $reset().`


### PR DESCRIPTION
Fix #2052 

From #2053