### PR TITLE
fix: support "types" condition in "exports" field

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -27,6 +27,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -27,6 +27,7 @@
   },
   "sideEffects": false,
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs"
   },


### PR DESCRIPTION
TypeScript with `node16` or `moduleResolution: "bundler"` cannot find types. See: https://arethetypeswrong.github.io