### PR TITLE
chore: add .idea/ to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs-api
 packages/docs/api
 .yalc
 yalc.lock
+.idea


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
This PR adds the .idea folder to the .gitignore file so that it is ignored by Git. This folder contains local configuration files for JetBrains IDEs, such as WebStorm.

Ignoring this folder in Git will prevent unnecessary changes from being tracked and committed to the repository. It will also ensure that developers using different IDEs can work on the project without conflicts.

This is a minor change, but it will improve the consistency and cleanliness of the repository.