### PR TITLE
ci: fix GitHub Actions Deprecating save-state and set-output commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
         with:
-          version: 7
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
+          node-version: 16.x
           cache: 'pnpm'
 
       - run: pnpm install


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
fix github action :The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
![image](https://user-images.githubusercontent.com/17453452/230533762-0d9a26c4-b38a-4ba7-a09b-b62e1450ab50.png)
