### PR TITLE
docs(zh): update state.md about `$reset`

### DIFF
--- a/packages/docs/zh/core-concepts/state.md
+++ b/packages/docs/zh/core-concepts/state.md
@@ -86,7 +86,7 @@ store.count++
 
 ## 重置 state %{#resetting-the-state}%
 
-你可以通过调用 store 的 `$reset()` 方法将 state 重置为初始值。
+使用选项式 API 的用法时，你可以通过调用 store 的 `$reset()` 方法将 state 重置为初始值。
 
 ```js
 const store = useStore()

--- a/packages/docs/zh/core-concepts/state.md
+++ b/packages/docs/zh/core-concepts/state.md
@@ -86,7 +86,7 @@ store.count++
 
 ## 重置 state %{#resetting-the-state}%
 
-使用选项式 API 的用法时，你可以通过调用 store 的 `$reset()` 方法将 state 重置为初始值。
+使用[选项式 API](/zh/core-concepts/index.md#option-stores) 时，你可以通过调用 store 的 `$reset()` 方法将 state 重置为初始值。
 
 ```js
 const store = useStore()


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
In English Doc:

> In [Option Stores](/core-concepts/index.md#option-stores), you can _reset_ the state to its initial value by calling the `$reset()` method on the store:

But in Chinese Doc:

> 你可以通过调用 store 的 $reset() 方法将 state 重置为初始值。
