### PR TITLE
fix(nuxt): add workaround to preserve type output

### DIFF
--- a/packages/nuxt/src/runtime/plugin.vue3.ts
+++ b/packages/nuxt/src/runtime/plugin.vue3.ts
@@ -1,7 +1,8 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { defineNuxtPlugin } from '#app'
+import type { Pinia } from 'pinia'
+import { defineNuxtPlugin, Plugin } from '#app'
 
-export default defineNuxtPlugin((nuxtApp) => {
+const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin((nuxtApp) => {
   const pinia = createPinia()
   nuxtApp.vueApp.use(pinia)
   setActivePinia(pinia)
@@ -19,3 +20,5 @@ export default defineNuxtPlugin((nuxtApp) => {
     },
   }
 })
+
+export default plugin


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

This adds a workaround to ensure types for plugin are preserved in build output. This should, however, be handled upstream in `nuxt-module-builder`.

resolves https://github.com/vuejs/pinia/issues/2071