### PR TITLE
fix(types): typescript 5.0 acceptHMRUpdate error (#2098)

### DIFF
--- a/packages/pinia/src/hmr.ts
+++ b/packages/pinia/src/hmr.ts
@@ -1,6 +1,6 @@
 import { isRef, isReactive, isVue2, set } from 'vue-demi'
 import { Pinia } from './rootStore'
-import { isPlainObject, StoreDefinition, StoreGeneric, _Method } from './types'
+import { isPlainObject, StateTree, StoreDefinition, StoreGeneric, _GettersTree, _Method } from './types'
 
 /**
  * Checks if a function is a `StoreDefinition`.
@@ -70,7 +70,7 @@ export function patchObject(
  * @param initialUseStore - return of the defineStore to hot update
  * @param hot - `import.meta.hot`
  */
-export function acceptHMRUpdate(initialUseStore: StoreDefinition, hot: any) {
+export function acceptHMRUpdate<Id extends string, S extends StateTree = {}, G extends _GettersTree<S> = {}, A = {}>(initialUseStore: StoreDefinition<Id, S, G, A>, hot: any) {
   // strip as much as possible from iife.prod
   if (!__DEV__) {
     return () => {}


### PR DESCRIPTION
My attempt at fixing the type error, basically allow typescript to infer the generic parameters of the store definition as is done in a few other places such as mapState.