### PR TITLE
feat(dx): throw an error if store id is missing

### DIFF
--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -379,4 +379,10 @@ describe('Store', () => {
       `[🍍]: A getter cannot have the same name as another state property. Rename one of them. Found with "anyName" in store "main".`
     ).toHaveBeenWarnedTimes(1)
   })
+
+  it('throws an error if no store id is provided', () => {
+    expect(() => defineStore({} as any)).toThrowError(
+      '[🍍]: defineStore must be passed an id string, either as its first argument or via the "id" option.'
+    )
+  })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -882,7 +882,7 @@ export function defineStore(
 
     if (__DEV__ && typeof id !== 'string') {
       throw new Error(
-        `[🍍]: defineStore must be passed an id string, either as its first argument or via the "id" option.`
+        `[🍍]: "defineStore()" must be passed a store id as its first argument.`
       )
     }
   }

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -879,6 +879,12 @@ export function defineStore(
   } else {
     options = idOrOptions
     id = idOrOptions.id
+
+    if (__DEV__ && typeof id !== 'string') {
+      throw new Error(
+        `[🍍]: defineStore must be passed an id string, either as its first argument or via the "id" option.`
+      )
+    }
   }
 
   function useStore(pinia?: Pinia | null, hot?: StoreGeneric): StoreGeneric {


### PR DESCRIPTION
Calling `defineStore` without an id appears to succeed, but it fails when calling `useStore`:

```
Cannot read properties of undefined (reading 'startsWith')
    at devtoolsPlugin (pinia.mjs:925:19)
    at pinia.mjs:1631:48
    at EffectScope.run (reactivity.esm-bundler.js:37:24)
    at pinia.mjs:1631:38
    at Array.forEach (<anonymous>)
    at createSetupStore (pinia.mjs:1628:14)
    at createOptionsStore (pinia.mjs:1223:13)
    at useStore (pinia.mjs:1705:17)
```

The `undefined` id causes various other problems, but this just happens to be the first line that throws an error.

I've encountered this a few times on Vue Land, so I thought it might be better to have an explicit error in dev that explains what the problem is.