### PR TITLE
docs: unify naming of store

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -26,7 +26,7 @@ To unit test a store, the most important part is creating a `pinia` instance:
 ```js
 // stores/counter.spec.ts
 import { setActivePinia, createPinia } from 'pinia'
-import { useCounter } from '../src/stores/counter'
+import { useCounterStore } from '../src/stores/counter'
 
 describe('Counter Store', () => {
   beforeEach(() => {
@@ -37,14 +37,14 @@ describe('Counter Store', () => {
   })
 
   it('increments', () => {
-    const counter = useCounter()
+    const counter = useCounterStore()
     expect(counter.n).toBe(0)
     counter.increment()
     expect(counter.n).toBe(1)
   })
 
   it('increments by amount', () => {
-    const counter = useCounter()
+    const counter = useCounterStore()
     counter.increment(10)
     expect(counter.n).toBe(10)
   })
@@ -188,7 +188,7 @@ By default, any getter will be computed like regular usage but you can manually 
 import { defineStore } from 'pinia'
 import { createTestingPinia } from '@pinia/testing'
 
-const useCounter = defineStore('counter', {
+const useCounterStore = defineStore('counter', {
   state: () => ({ n: 1 }),
   getters: {
     double: (state) => state.n * 2,
@@ -196,7 +196,7 @@ const useCounter = defineStore('counter', {
 })
 
 const pinia = createTestingPinia()
-const counter = useCounter(pinia)
+const counter = useCounterStore(pinia)
 
 counter.double = 3 // 🪄 getters are writable only in tests
 


### PR DESCRIPTION
As [best practices describes](https://pinia.vuejs.org/core-concepts/#defining-a-store), stores should be named `useXXXStore`. This PR unifies the naming of `counter` store on the [testing](https://pinia.vuejs.org/cookbook/testing.html) section
