### PR TITLE
fix(testing): clarify createSpy docs

### DIFF
--- a/packages/testing/src/testing.ts
+++ b/packages/testing/src/testing.ts
@@ -65,7 +65,8 @@ export interface TestingOptions {
 
   /**
    * Function used to create a spy for actions and `$patch()`. Pre-configured
-   * with `jest.fn()` in jest projects or `vi.fn()` in vitest projects.
+   * with `jest.fn` in Jest projects or `vi.fn` in Vitest projects if 
+   * `globals: true` is set.
    */
   createSpy?: (fn?: (...args: any[]) => any) => (...args: any[]) => any
 }


### PR DESCRIPTION
The old wording made it sound like `vi.fn()` should be supplied when it should be `vi.fn` instead.

Additionally, there is super weird stuff happening if you supply `vi.fn()` so maybe that should be looked into at some point.
