### PR TITLE
chore: update `$state` JSDoc to reflect internal patching

### DIFF
--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -321,7 +321,7 @@ export interface _StoreWithState<
   A /* extends ActionsTree */
 > extends StoreProperties<Id> {
   /**
-   * State of the Store. Setting it will patch the state via `$patch()` internally.
+   * State of the Store. Setting it will internally call `$patch()` to update the state.
    */
   $state: UnwrapRef<S> & PiniaCustomStateProperties<S>
 

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -321,7 +321,7 @@ export interface _StoreWithState<
   A /* extends ActionsTree */
 > extends StoreProperties<Id> {
   /**
-   * State of the Store. Setting it will replace the whole state.
+   * State of the Store. Setting it will patch the state via `$patch()` internally.
    */
   $state: UnwrapRef<S> & PiniaCustomStateProperties<S>
 


### PR DESCRIPTION
The purpose of this PR is to update the JSDoc of `$state` to reflect that when setting state, the state store will be patched via the `$patch()` method internally, rather than completely replacing the entire state store. 