### PR TITLE
refactor: reduce the unnecessary use of `markRaw`

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -255,8 +255,8 @@ function createSetupStore<
   // internal state
   let isListening: boolean // set to true at the end
   let isSyncListening: boolean // set to true at the end
-  let subscriptions: SubscriptionCallback<S>[] = markRaw([])
-  let actionSubscriptions: StoreOnActionListener<Id, S, G, A>[] = markRaw([])
+  let subscriptions: SubscriptionCallback<S>[] = []
+  let actionSubscriptions: StoreOnActionListener<Id, S, G, A>[] = []
   let debuggerEvents: DebuggerEvent[] | DebuggerEvent
   const initialState = pinia.state.value[$id] as UnwrapRef<S> | undefined
 


### PR DESCRIPTION
Is it necessary to use `markRaw` for `actionSubscriptions` and `subscriptions` here?

https://github.com/vuejs/pinia/blob/d710cb8ee4c947322f56668f54eea00be7ebbfd9/packages/pinia/src/store.ts#L258-L259

I have examined the context of the source code, and it appears that `actionSubscriptions` and `subscriptions` are never potentially converted to proxy at any point in the code. Additionally, users do not have access to these arrays. Given this information, is it still necessary to use `markRaw` for them?
