### PR TITLE
fix: does not provide an export named 'hasInjectioncontext’

### DIFF
--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -1,8 +1,8 @@
+import { hasInjectionContext } from 'vue'
 import {
   App,
   EffectScope,
   inject,
-  hasInjectionContext,
   InjectionKey,
   Ref,
 } from 'vue-demi'

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -1,8 +1,8 @@
+import { hasInjectionContext } from 'vue'
 import {
   watch,
   computed,
   inject,
-  hasInjectionContext,
   getCurrentInstance,
   reactive,
   DebuggerEvent,


### PR DESCRIPTION


<img width="1012" alt="image" src="https://github.com/vuejs/pinia/assets/47295879/15257600-992c-4b10-8746-e4fda1b47d0d">

