### PR TITLE
fix(devtools): Do not patch mocked actions

### DIFF
--- a/packages/pinia/__tests__/devtools.spec.ts
+++ b/packages/pinia/__tests__/devtools.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, defineStore } from '../src'
+import { devtoolsPlugin } from '../src/devtools'
+
+describe('devtoolsPlugin', () => {
+  const useStore = defineStore('test', {
+    actions: {
+      myAction() {
+        return 42
+      },
+    },
+  })
+
+  it('preserves mocked actions during testing', () => {
+    const pinia = createPinia()
+    // Simulate using createTestingPinia
+    pinia._testing = true
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    // Simulate mocking with @pinia/testing createSpy
+    pinia.use(({ store, options }) => {
+      Object.keys(options.actions).forEach((action) => {
+        store[action]._mockImplementation = () => {}
+      })
+    })
+    // Previously the mocked actions would be wrapped again
+    pinia.use(devtoolsPlugin)
+
+    const store = useStore(pinia)
+
+    // @ts-expect-error we have not actually loaded @pinia/testing and mocked actions
+    expect(store.myAction._mockImplementation).toBeDefined()
+  })
+})

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -566,21 +566,24 @@ export function devtoolsPlugin<
   // detect option api vs setup api
   store._isOptionsAPI = !!options.state
 
-  patchActionForGrouping(
-    store as StoreGeneric,
-    Object.keys(options.actions),
-    store._isOptionsAPI
-  )
-
-  // Upgrade the HMR to also update the new actions
-  const originalHotUpdate = store._hotUpdate
-  toRaw(store)._hotUpdate = function (newStore) {
-    originalHotUpdate.apply(this, arguments as any)
+  // Do not overwrite actions mocked by @pinia/testing (#2298)
+  if (!store._p._testing) {
     patchActionForGrouping(
       store as StoreGeneric,
-      Object.keys(newStore._hmrPayload.actions),
-      !!store._isOptionsAPI
+      Object.keys(options.actions),
+      store._isOptionsAPI
     )
+
+    // Upgrade the HMR to also update the new actions
+    const originalHotUpdate = store._hotUpdate
+    toRaw(store)._hotUpdate = function (newStore) {
+      originalHotUpdate.apply(this, arguments as any)
+      patchActionForGrouping(
+        store as StoreGeneric,
+        Object.keys(newStore._hmrPayload.actions),
+        !!store._isOptionsAPI
+      )
+    }
   }
 
   addStoreToDevtools(


### PR DESCRIPTION
There were no devtools unittests afaics, so I added a new file.
Usually devtools are not loaded during unit tests, so I had to do the testing on the inner-most exposed level.
I am simulating a testing pinia with mocked actions and check that they are "sufficiently" preserved.

Fixes #2298 