### PR TITLE
fix:(plugin): all store state $subscribe watch callback fire when def…

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -428,22 +428,25 @@ function createSetupStore<
         () => stopWatcher()
       )
       const stopWatcher = scope.run(() =>
-        watch(
-          () => pinia.state.value[$id] as UnwrapRef<S>,
-          (state) => {
-            if (options.flush === 'sync' ? isSyncListening : isListening) {
-              callback(
-                {
-                  storeId: $id,
-                  type: MutationType.direct,
-                  events: debuggerEvents as DebuggerEvent,
-                },
-                state
-              )
-            }
-          },
-          assign({}, $subscribeOptions, options)
-        )
+        {    
+          const state = pinia.state.value[$id]
+          return watch(
+            () => state as UnwrapRef<S>,
+            (state) => {
+              if (options.flush === 'sync' ? isSyncListening : isListening) {
+                callback(
+                  {
+                    storeId: $id,
+                    type: MutationType.direct,
+                    events: debuggerEvents as DebuggerEvent,
+                  },
+                  state
+                )
+              }
+            },
+            assign({}, $subscribeOptions, options)
+          )
+        }
       )!
 
       return removeSubscription


### PR DESCRIPTION
fix: every store state $subscribe watch callback execute when run `defineStore` to  setup a new store

**The situation now:**

> for example: 
> 
> 1.  there was store-A, store-B
> 2. run `defineStore` to setup store-C
> 3. `$subscribe` callback execute , store-A, store-B change too
> 
> 
> ```
>   import { createPinia, PiniaPluginContext } from 'pinia'
> 
>   const plugin = (context: PiniaPluginContext) => {
>     context.store.$subscribe(
>       (mutation, state) => {
>         //
>       }
>     )
>   }
> 
>   const pinia = createPinia()
>   pinia.use(plugin)
> 
> ```

**What to Expect**

>  1.  there was store-A, store-B
> 2. run `defineStore` to setup store-C
> 3. `$subscribe` callback execute , but store-A, store-B  not change, only store-C change