### PR TITLE
docs: add info about Nuxt 3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,7 @@ new Vue({
 })
 ```
 
-```js
-// Nuxt 3
-export default defineNuxtConfig({
-  // ... other options
-  modules: [
-    // ...
-    '@pinia/nuxt',
-  ],
-})
-```
+For more detailed instructions, including [Nuxt configuration](https://pinia.vuejs.org/ssr/nuxt.html#nuxt-js), check the [Documentation](https://pinia.vuejs.org).
 
 ### Create a Store
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ new Vue({
 })
 ```
 
+```js
+// Nuxt 3
+export default defineNuxtConfig({
+  // ... other options
+  modules: [
+    // ...
+    '@pinia/nuxt',
+  ],
+})
+```
+
 ### Create a Store
 
 You can create as many stores as you want, and they should each exist in different files:


### PR DESCRIPTION
Because the README is included on the Nuxt module page (https://nuxt.com/modules/pinia) it might be confusing to only see information about how to install it in a plain Vue.js application.
