### PR TITLE
docs: Update testing.md with setActivePinia() method

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -73,12 +73,16 @@ And make sure to create a testing pinia in your tests when mounting a component:
 ```js
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 // import any store you want to interact with in tests
 import { useSomeStore } from '@/stores/myStore'
 
+// Depending on your test framework, you may need to specify a createSpy function to the createTestingPinia method 
+const pinia = createTestingPinia()
+setActivePinia(pinia)
 const wrapper = mount(Counter, {
   global: {
-    plugins: [createTestingPinia()],
+    plugins: [pinia],
   },
 })
 


### PR DESCRIPTION
I have found that if I don't call the `setActivePinia()` method it throws and error `getActivePinia() was called but there was no active Pinia`
