### PR TITLE
fix: broken play button on Vue School links

### DIFF
--- a/packages/docs/.vitepress/theme/components/VueSchoolLink.vue
+++ b/packages/docs/.vitepress/theme/components/VueSchoolLink.vue
@@ -5,6 +5,7 @@
       target="_blank"
       rel="sponsored noopener"
       :title="title"
+      class="no-icon"
     >
       <slot>{{ translations[site.lang] }}</slot>
     </a>


### PR DESCRIPTION
This:
<img width="439" alt="Screenshot 2023-08-18 at 10 10 47 AM" src="https://github.com/vuejs/pinia/assets/7635209/7795f371-71b6-40db-9a20-f12a5b382e84">


becomes this:
<img width="462" alt="Screenshot 2023-08-18 at 10 11 02 AM" src="https://github.com/vuejs/pinia/assets/7635209/bb4a929b-bc7b-4823-ade4-1f6023604cb2">

Thanks!