### PR TITLE
Docs: Add Link to Vue.js Certification

### DIFF
--- a/packages/docs/.vitepress/config/en.ts
+++ b/packages/docs/.vitepress/config/en.ts
@@ -42,6 +42,10 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
             text: 'Changelog',
             link: 'https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md',
           },
+          {
+            text: 'Vue.js Certification',
+            link: 'https://certification.vuejs.org/?friend=VUEROUTER',
+          },
         ],
       },
     ],


### PR DESCRIPTION
This PR adds the link to the Vue.js Certification in the Navbar.

![image](https://github.com/vuejs/pinia/assets/3766839/308ed7d5-4143-40e9-bc28-7e0d09d2b0c5)
