### PR TITLE
fix: missing vue-demi export hasInjectionContext, upgrade to v0.14.6

### DIFF
--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@vue/devtools-api": "^6.5.0",
-    "vue-demi": ">=0.14.5"
+    "vue-demi": ">=0.14.6"
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^2.6.14 || ^3.3.0
         version: 3.3.4
       vue-demi:
-        specifier: '>=0.14.5'
-        version: 0.14.5(@vue/composition-api@1.4.0)(vue@3.3.4)
+        specifier: '>=0.14.6'
+        version: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 7.34.4
@@ -221,7 +221,7 @@ importers:
     dependencies:
       vue-demi:
         specifier: '>=0.14.5'
-        version: 0.14.5(@vue/composition-api@1.4.0)(vue@3.3.4)
+        version: 0.14.5(vue@3.3.4)
     devDependencies:
       pinia:
         specifier: workspace:^2.0.18
@@ -2370,7 +2370,7 @@ packages:
       '@types/web-bluetooth': 0.0.17
       '@vueuse/metadata': 10.3.0
       '@vueuse/shared': 10.3.0(vue@3.3.4)
-      vue-demi: 0.14.5(vue@3.3.4)
+      vue-demi: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2420,7 +2420,7 @@ packages:
       '@vueuse/core': 10.3.0(vue@3.3.4)
       '@vueuse/shared': 10.3.0(vue@3.3.4)
       focus-trap: 7.5.2
-      vue-demi: 0.14.5(vue@3.3.4)
+      vue-demi: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2437,7 +2437,7 @@ packages:
   /@vueuse/shared@10.1.2(vue@3.3.4):
     resolution: {integrity: sha512-1uoUTPBlgyscK9v6ScGeVYDDzlPSFXBlxuK7SfrDGyUTBiznb3mNceqhwvZHjtDRELZEN79V5uWPTF1VDV8svA==}
     dependencies:
-      vue-demi: 0.14.5(vue@3.3.4)
+      vue-demi: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -2446,7 +2446,7 @@ packages:
   /@vueuse/shared@10.3.0(vue@3.3.4):
     resolution: {integrity: sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==}
     dependencies:
-      vue-demi: 0.14.5(vue@3.3.4)
+      vue-demi: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -8053,22 +8053,6 @@ packages:
       vue: 3.3.4
     dev: false
 
-  /vue-demi@0.14.5(@vue/composition-api@1.4.0)(vue@3.3.4):
-    resolution: {integrity: sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-    dependencies:
-      '@vue/composition-api': 1.4.0(vue@3.3.4)
-      vue: 3.3.4
-    dev: false
-
   /vue-demi@0.14.5(vue@3.3.4):
     resolution: {integrity: sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==}
     engines: {node: '>=12'}
@@ -8081,6 +8065,22 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
+      vue: 3.3.4
+    dev: false
+
+  /vue-demi@0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4):
+    resolution: {integrity: sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      '@vue/composition-api': 1.4.0(vue@3.3.4)
       vue: 3.3.4
     dev: false
 
@@ -8098,7 +8098,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.3.4
-      vue-demi: 0.14.5(@vue/composition-api@1.4.0)(vue@3.3.4)
+      vue-demi: 0.14.6(@vue/composition-api@1.4.0)(vue@3.3.4)
     dev: false
 
   /vue-router@4.2.0(vue@3.3.2):


### PR DESCRIPTION
https://github.com/vuejs/pinia/issues/2388