### PR TITLE
docs(zh):  core concepts

### DIFF
--- a/packages/docs/zh/core-concepts/index.md
+++ b/packages/docs/zh/core-concepts/index.md
@@ -50,11 +50,12 @@ export const useCounterStore = defineStore('counter', {
 ```js
 export const useCounterStore = defineStore('counter', () => {
   const count = ref(0)
+  const double = computed(() => count.value * 2)
   function increment() {
     count.value++
   }
 
-  return { count, increment }
+  return { count, double, increment }
 })
 ```
 
@@ -95,15 +96,15 @@ const store = useCounterStore()
 const store = useCounterStore()
 // ❌ 这将不起作用，因为它破坏了响应性
 // 这就和直接解构 `props` 一样
-const { name, doubleCount } = store // [!code warning]
-name // 将始终是 "Eduardo" // [!code warning]
-doubleCount // 将始终是 0 // [!code warning]
+const { count, doubleCount } = store // [!code warning]
+count // 将始终是 "Eduardo" // [!code warning]
+double // 将始终是 0 // [!code warning]
 setTimeout(() => {
   store.increment()
 }, 1000)
 // ✅ 这样写是响应式的
-// 💡 当然你也可以直接使用 `store.doubleCount`
-const doubleValue = computed(() => store.doubleCount)
+// 💡 当然你也可以直接使用 `store.double`
+const doubleValue = computed(() => store.double)
 </script>
 ```
 
@@ -116,7 +117,7 @@ const store = useCounterStore()
 // `name` 和 `doubleCount` 是响应式的 ref
 // 同时通过插件添加的属性也会被提取为 ref
 // 并且会跳过所有的 action 或非响应式 (不是 ref 或 reactive) 的属性
-const { name, doubleCount } = storeToRefs(store)
+const { count, double } = storeToRefs(store)
 // 作为 action 的 increment 可以直接解构
 const { increment } = store
 </script>


### PR DESCRIPTION
更新为语义更加明确的代码例子。
代码说明中缺少double，并且line119中出现了上文例子中并未定义的name，让读者有点不明所以。
