### PR TITLE
Fix Vuex comparison link

### DIFF
--- a/packages/docs/cookbook/migration-vuex.md
+++ b/packages/docs/cookbook/migration-vuex.md
@@ -270,7 +270,7 @@ More details can be found [here](../core-concepts/outside-component-usage.md).
 
 ## Advanced Vuex Usage
 
-In the case your Vuex store using some of the more advanced features it offers, here is some guidance on how to accomplish the same in Pinia. Some of these points are already covered in [this comparison summary](../introduction.md#comparison-with-vuex-3-x-4-x).
+In the case your Vuex store using some of the more advanced features it offers, here is some guidance on how to accomplish the same in Pinia. Some of these points are already covered in [this comparison summary](../introduction.md#Comparison-with-Vuex-3-x-4-x).
 
 ### Dynamic Modules
 


### PR DESCRIPTION
This link was taking users to the introduction page, I fixed it to take users to the right section of the introduction page

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
