### PR TITLE
Remove duplicated Migration from Vuex link

### DIFF
--- a/packages/docs/.vitepress/config/en.ts
+++ b/packages/docs/.vitepress/config/en.ts
@@ -139,10 +139,6 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
               link: '/cookbook/vscode-snippets.html',
             },
             {
-              text: 'Migration from Vuex',
-              link: '/cookbook/migration-vuex.html',
-            },
-            {
               text: 'Migration from v0/v1 to v2',
               link: '/cookbook/migration-v1-v2.html',
             },


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

This link was duplicated, I just removed the second one ([Migration from Vuex ≤4](https://pinia.vuejs.org/cookbook/migration-vuex.html)) and I kept the first link in the sidebar menu because the title of the page was matched with the first link I preferred to delete the second one (Migration from Vuex).
