### PR TITLE
Do not add unofficial plugin

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -33,8 +33,6 @@ app.use(pinia)
 app.mount('#app')
 ```
 
-If you are using Vue 2, you also need to install a plugin and inject the created `pinia` at the root of the app:
-
 ```js {1,3-4,12}
 import { createPinia, PiniaVuePlugin } from 'pinia'
 


### PR DESCRIPTION
# Description

If we want Pinia to be seriously taken, then not well tested and not supported by the wider community (consumers), then it should not be added. It creates confusion in the implementation and usage of Pinia.