### PR TITLE
docs: Add link to Russian docs

### DIFF
--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -29,5 +29,10 @@ export default defineConfig({
       lang: 'uk-UA',
       link: 'https://pinia-ua.netlify.app',
     },
+    ru: {
+      label: 'Русский',
+      lang: 'ru-RU',
+      link: 'https://pinia-ru.netlify.app',
+    },
   },
 })


### PR DESCRIPTION
Hello. Could you please add a link to the documentation in Russian?

At the moment, I am actively translating documentation, and I hope that this pull request will attract more people to join the translation effort.

I am also translating documentation for Vue.js (https://github.com/translation-gang/docs-ru). Unfortunately, the maintainer is no longer active and does not review pull requests, even though the translation is almost 100% complete (all changes are in pull requests).

The plan is to start with translating the Pinia documentation, then move on to Vue Router, Vuex, and also complete the translation of the Vue.js documentation (the link is provided above).

Thanks.