### PR TITLE
fix: force active correctly scope in vue2

### DIFF
--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   ComputedRef,
   DebuggerEvent,
+  EffectScope,
   Ref,
   UnwrapRef,
   WatchOptions,
@@ -423,6 +424,7 @@ export interface _StoreWithState<
    * @internal
    */
   _r?: boolean
+  _s?: EffectScope
 }
 
 /**


### PR DESCRIPTION
This resolves the error scope issue caused on Vue 2 due to the callHook.

closed #1800 
