### PR TITLE
fix: contrast problems with dark theme tip block in docs

### DIFF
--- a/packages/docs/.vitepress/theme/styles/vars.css
+++ b/packages/docs/.vitepress/theme/styles/vars.css
@@ -62,7 +62,6 @@ html.dark:root {
   --vp-c-brand-1: var(--c-yellow-1);
   --vp-c-brand-2: var(--c-yellow-2);
   --vp-c-brand-3: var(--c-yellow-3);
-  --vp-c-brand-soft: var(--c-yellow-soft-1);
 
   --vp-c-bg-alpha-with-backdrop: rgba(20, 25, 36, 0.7);
   --vp-c-bg-alpha-without-backdrop: rgba(20, 25, 36, 0.9);


### PR DESCRIPTION
While navigating the docs in dark mode I came across a 'Tip' block with a color combination that was difficult to read, yellow and white on yellow: 
<img width="708" alt="Screenshot 2023-10-22 at 18 17 21" src="https://github.com/vuejs/pinia/assets/1307818/7dad2b1c-b1b4-4681-a052-d51228f8e646">



The above tip block can be found on the following page of the docs, while in dark mode: https://pinia.vuejs.org/core-concepts/state.html


This PR removes a custom theme value assignment that makes the tip's `background-colour` yellow.


## Local testing
<img width="718" alt="Screenshot 2023-10-22 at 18 16 29" src="https://github.com/vuejs/pinia/assets/1307818/247cf667-3fa7-4a30-b3d1-a388e7e523f1">


It's a bit better, in terms of contrast. 