### PR TITLE
chore(playground): implicit conversion of a 'symbol' to a 'string' will fail at run…

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -40,7 +40,9 @@ const pages = router
 
 const sourceCodeLink = computed(() => {
   if (route.name) {
-    return `https://github.com/vuejs/pinia/blob/v2/packages/playground/src/views/${route.name}.vue`
+    return `https://github.com/vuejs/pinia/blob/v2/packages/playground/src/views/${String(
+      route.name
+    )}.vue`
   } else {
     return `https://github.com/vuejs/pinia/blob/v2/packages/playground/src/`
   }


### PR DESCRIPTION
I'm not sure if this ide error is a runtime bug, but it tells me that I can wrap it with a String function so that it can be converted to a string type better. 

The following is the screenshot before the modification, and the subsequent screenshot is modified by me, and it can normally jump to the corresponding component after local operation.

pre: 
![CH77 (O92$DFLOCO Q%TLKE](https://github.com/vuejs/pinia/assets/48849602/5aaddd2a-cc8d-4ffc-9c7f-4f74ac78b0ed)
after:
![_ %6N875HA$SA(S69HV`%J0](https://github.com/vuejs/pinia/assets/48849602/9c8aa804-20aa-40dc-bf4f-5c33a61387d5)

Test step: 

Click on the about route, you can see the address of the jump, which is the correct component address in the pinia source code in github. If you don't think this is an error, please reply to me and I will close the pull request

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
