### PR TITLE
docs: update the nuxt labs sponsor link

### DIFF
--- a/packages/docs/.vitepress/theme/components/sponsors.json
+++ b/packages/docs/.vitepress/theme/components/sponsors.json
@@ -35,7 +35,7 @@
       "alt": "Storyblok"
     },
     {
-      "href": "https://nuxtjs.org",
+      "href": "https://nuxtlabs.com/",
       "imgSrcLight": "https://posva-sponsors.pages.dev/logos/nuxt-light.svg",
       "imgSrcDark": "https://posva-sponsors.pages.dev/logos/nuxt-dark.svg",
       "alt": "Nuxt Labs"


### PR DESCRIPTION
I am just updating the **NuxtLabs** URL link that will send the user to their actual website.