### PR TITLE
docs: Added alternative way of defining the state with reactive instead of ref

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -70,6 +70,33 @@ In _Setup Stores_:
 
 Note you **must** return **all state properties** in setup stores for pinia to pick them up as state. In other words, you cannot have _private_ state properties in stores.
 
+An alternative to using `ref()`s internally in the state is to use `reactive()` to define the `state`:
+
+```js
+import { toRefs } from 'vue';
+
+export const useCounterStore = defineStore('counter', () => {
+  const state = reactive({
+    count: 0,
+    name: 'Eduardo',
+  })
+  
+  const doubleCount = computed(() => state.count * 2)
+  
+  function increment() {
+    state.count++
+  }
+
+  return {
+    ...toRefs(state),
+    doubleCount,
+    increment,
+  };
+})
+```
+
+The big advantage of this is the removal of `.value` when accessing state properties as you can see in the `doubleCount` getter and the `increment` function.  However, you must use `toRefs()` when returning the `state` from the store to make sure the `state` properties are reactive. If you forget to use `toRefs()`, the `state` properties will not be reactive when used outside the store.
+
 Setup stores bring a lot more flexibility than [Option Stores](#option-stores) as you can create watchers within a store and freely use any [composable](https://vuejs.org/guide/reusability/composables.html#composables). However, keep in mind that using composables will get more complex when using [SSR](../cookbook/composables.md).
 
 Setup stores are also able to rely on globally _provided_ properties like the Router or the Route. Any property [provided at the App level](https://vuejs.org/api/application.html#app-provide) can be accessed from the store using `inject()`, just like in components:


### PR DESCRIPTION
Hi, 

A method I've been using for a long time when setting up my Pinia stores is to use `reactive` instead of `refs` which has a few advantages:
 - The getters/actions can reference the state without the use of `.value`
 - Any other stores and or components will not notice a difference as the state is converted to `refs` before it is returned through the use of `toRefs()`

I've added this method to the documentation. I have used this method extensively without any downsides in my projects and it seems to be an improvement over the current recommended store setup. 