### PR TITLE
docs: add link to Vite HMR API

### DIFF
--- a/packages/docs/cookbook/hot-module-replacement.md
+++ b/packages/docs/cookbook/hot-module-replacement.md
@@ -2,7 +2,7 @@
 
 Pinia supports Hot Module replacement so you can edit your stores and interact with them directly in your app without reloading the page, allowing you to keep the existing state, add, or even remove state, actions, and getters.
 
-At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). For more information about Vite HMR API, please consult the [documentation](https://vitejs.dev/guide/api-hmr.html#hmr-api).
+At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). For more information about Vite HMR API, please consult the [documentation](https://vitejs.dev/guide/api-hmr.html#hmr-api).  
 You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `cart.js`, and `chat.js`, you will have to add (and adapt) this after the creation of the _store definition_:
 
 ```js

--- a/packages/docs/cookbook/hot-module-replacement.md
+++ b/packages/docs/cookbook/hot-module-replacement.md
@@ -2,7 +2,7 @@
 
 Pinia supports Hot Module replacement so you can edit your stores and interact with them directly in your app without reloading the page, allowing you to keep the existing state, add, or even remove state, actions, and getters.
 
-At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`).
+At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). For more information about Vite HMR API, please consult the [documentation](https://vitejs.dev/guide/api-hmr.html#hmr-api).
 You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `cart.js`, and `chat.js`, you will have to add (and adapt) this after the creation of the _store definition_:
 
 ```js

--- a/packages/docs/cookbook/hot-module-replacement.md
+++ b/packages/docs/cookbook/hot-module-replacement.md
@@ -2,7 +2,7 @@
 
 Pinia supports Hot Module replacement so you can edit your stores and interact with them directly in your app without reloading the page, allowing you to keep the existing state, add, or even remove state, actions, and getters.
 
-At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). For more information about Vite HMR API, please consult the [documentation](https://vitejs.dev/guide/api-hmr.html#hmr-api).  
+At the moment, only [Vite](https://vitejs.dev/guide/api-hmr.html#hmr-api) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). 
 You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `cart.js`, and `chat.js`, you will have to add (and adapt) this after the creation of the _store definition_:
 
 ```js


### PR DESCRIPTION
This PR includes a patch that adds a link to Vite's documentation for the readers who may find unfamiliar with Vite's `import.meta.hot` API.