### PR TITLE
refactor(nuxt): use object syntax for nuxt 3 plugin

### DIFF
--- a/packages/nuxt/src/runtime/plugin.vue3.ts
+++ b/packages/nuxt/src/runtime/plugin.vue3.ts
@@ -2,22 +2,25 @@ import { createPinia, setActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
 import { defineNuxtPlugin, Plugin } from '#app'
 
-const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin((nuxtApp) => {
-  const pinia = createPinia()
-  nuxtApp.vueApp.use(pinia)
-  setActivePinia(pinia)
+const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin({
+  name: 'pinia',
+  setup(nuxtApp) {
+    const pinia = createPinia()
+    nuxtApp.vueApp.use(pinia)
+    setActivePinia(pinia)
 
-  if (process.server) {
-    nuxtApp.payload.pinia = pinia.state.value
-  } else if (nuxtApp.payload && nuxtApp.payload.pinia) {
-    pinia.state.value = nuxtApp.payload.pinia
-  }
+    if (process.server) {
+      nuxtApp.payload.pinia = pinia.state.value
+    } else if (nuxtApp.payload && nuxtApp.payload.pinia) {
+      pinia.state.value = nuxtApp.payload.pinia
+    }
 
-  // Inject $pinia
-  return {
-    provide: {
-      pinia,
-    },
+    // Inject $pinia
+    return {
+      provide: {
+        pinia,
+      },
+    }
   }
 })
 


### PR DESCRIPTION
Hello this PR adds a name to the pinia nuxt plugin.

This will be necessary for plugins that relies on pinia, they'll be using the `dependsOn` property that require plugins to be named. In Nuxt 4, all plugins will be loaded in parallel by default