### PR TITLE
fix(types): fix storeToRefs state return type (#2574)

### DIFF
--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -11,7 +11,12 @@ import {
   toRefs,
 } from 'vue-demi'
 import { StoreGetters, StoreState } from './store'
-import type { PiniaCustomStateProperties, StoreGeneric } from './types'
+import type {
+  _UnwrapAll,
+  PiniaCustomStateProperties,
+  Store,
+  StoreGeneric,
+} from './types'
 
 type ToComputedRefs<T> = {
   [K in keyof T]: ToRef<T[K]> extends Ref<infer U>
@@ -20,12 +25,24 @@ type ToComputedRefs<T> = {
 }
 
 /**
+ * Extracts the refs of a state object from a store. If the state value is a Ref or type that extends ref, it will be kept as is.
+ * Otherwise, it will be converted into a Ref.
+ */
+type ToStateRefs<SS> =
+  SS extends Store<string, infer UnwrappedState>
+    ? UnwrappedState extends _UnwrapAll<Pick<infer State, infer Key>>
+      ? {
+          [K in Key]: State[K] extends Ref ? State[K] : Ref<State[K]>
+        }
+      : ToRefs<UnwrappedState>
+    : ToRefs<SS>
+
+/**
  * Extracts the return type for `storeToRefs`.
  * Will convert any `getters` into `ComputedRef`.
  */
-export type StoreToRefs<SS extends StoreGeneric> = ToRefs<
-  StoreState<SS> & PiniaCustomStateProperties<StoreState<SS>>
-> &
+export type StoreToRefs<SS extends StoreGeneric> = ToStateRefs<SS> &
+  ToRefs<PiniaCustomStateProperties<StoreState<SS>>> &
   ToComputedRefs<StoreGetters<SS>>
 
 /**

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -12,8 +12,11 @@ import {
 } from 'vue-demi'
 import { StoreGetters, StoreState } from './store'
 import type {
+  _ActionsTree,
+  _GettersTree,
   _UnwrapAll,
   PiniaCustomStateProperties,
+  StateTree,
   Store,
   StoreGeneric,
 } from './types'
@@ -28,14 +31,19 @@ type ToComputedRefs<T> = {
  * Extracts the refs of a state object from a store. If the state value is a Ref or type that extends ref, it will be kept as is.
  * Otherwise, it will be converted into a Ref.
  */
-type ToStateRefs<SS> =
-  SS extends Store<string, infer UnwrappedState>
+declare type ToStateRefs<SS> =
+  SS extends Store<
+    string,
+    infer UnwrappedState,
+    _GettersTree<StateTree>,
+    _ActionsTree
+  >
     ? UnwrappedState extends _UnwrapAll<Pick<infer State, infer Key>>
       ? {
-          [K in Key]: State[K] extends Ref ? State[K] : Ref<State[K]>
+          [K in Key]: ToRef<State[K]>
         }
       : ToRefs<UnwrappedState>
-    : ToRefs<SS>
+    : ToRefs<StoreState<SS>>
 
 /**
  * Extracts the return type for `storeToRefs`.

--- a/packages/pinia/test-dts/customizations.test-d.ts
+++ b/packages/pinia/test-dts/customizations.test-d.ts
@@ -214,3 +214,23 @@ expectType<{
     })()
   )
 )
+
+expectType<{
+  n: Ref<number>
+  customN: Ref<number> & { plusOne: () => void }
+  double: ComputedRef<number>
+  myState: Ref<number>
+  stateOnly: Ref<number>
+}>(
+  storeToRefs(
+    defineStore('a', {
+      state: () => ({
+        n: 1,
+        customN: ref(1) as Ref<number> & { plusOne: () => void },
+      }),
+      getters: {
+        double: (state) => state.n * 2,
+      },
+    })()
+  )
+)

--- a/packages/pinia/test-dts/customizations.test-d.ts
+++ b/packages/pinia/test-dts/customizations.test-d.ts
@@ -223,6 +223,33 @@ expectType<{
   stateOnly: Ref<number>
 }>(
   storeToRefs(
+    defineStore('a', () => {
+      const n = ref(1)
+      const customN = ref(1) as Ref<number> & { plusOne: () => void }
+      const double = computed(() => n.value * 2)
+
+      function plusOne() {
+        customN.value++
+      }
+
+      return {
+        n,
+        customN,
+        double,
+        plusOne,
+      }
+    })()
+  )
+)
+
+expectType<{
+  n: Ref<number>
+  customN: Ref<number> & { plusOne: () => void }
+  double: ComputedRef<number>
+  myState: Ref<number>
+  stateOnly: Ref<number>
+}>(
+  storeToRefs(
     defineStore('a', {
       state: () => ({
         n: 1,
@@ -230,6 +257,36 @@ expectType<{
       }),
       getters: {
         double: (state) => state.n * 2,
+      },
+      actions: {
+        plusOne() {
+          this.n++
+        },
+      },
+    })()
+  )
+)
+
+expectType<{
+  n: Ref<number>
+  customN: Ref<number> & { plusOne: () => void }
+  double: ComputedRef<number>
+  myState: Ref<number>
+  stateOnly: Ref<number>
+}>(
+  storeToRefs(
+    defineStore('a', {
+      state: () => ({
+        n: 1,
+        customN: ref(1) as Ref<number> & { plusOne: () => void },
+      }),
+      getters: {
+        double: (state) => state.n * 2,
+      },
+      actions: {
+        plusOne() {
+          this.n++
+        },
       },
     })()
   )

--- a/packages/pinia/test-dts/customizations.test-d.ts
+++ b/packages/pinia/test-dts/customizations.test-d.ts
@@ -121,13 +121,16 @@ expectType<{
 pinia.use(({ options, store }) => {
   const { debounce: debounceOptions } = options
   if (debounceOptions) {
-    return Object.keys(debounceOptions).reduce((debouncedActions, action) => {
-      debouncedActions[action] = debounce(
-        store[action],
-        debounceOptions[action]
-      )
-      return debouncedActions
-    }, {} as Record<string, (...args: any[]) => any>)
+    return Object.keys(debounceOptions).reduce(
+      (debouncedActions, action) => {
+        debouncedActions[action] = debounce(
+          store[action],
+          debounceOptions[action]
+        )
+        return debouncedActions
+      },
+      {} as Record<string, (...args: any[]) => any>
+    )
   }
 })
 
@@ -185,7 +188,28 @@ expectType<{
       const double = computed(() => n.value * 2)
       return {
         n,
-        double
+        double,
+      }
+    })()
+  )
+)
+
+expectType<{
+  n: Ref<number>
+  customN: Ref<number> & { plusOne: () => void }
+  double: ComputedRef<number>
+  myState: Ref<number>
+  stateOnly: Ref<number>
+}>(
+  storeToRefs(
+    defineStore('a', () => {
+      const n = ref(1)
+      const customN = ref(1) as Ref<number> & { plusOne: () => void }
+      const double = computed(() => n.value * 2)
+      return {
+        n,
+        customN,
+        double,
       }
     })()
   )


### PR DESCRIPTION
Add new mapped type to keep original ref type in the `storeToRefs` return type (close #2574)

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
