### PR TITLE
docs: fix and update module installation

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -5,9 +5,17 @@ Using Pinia with [Nuxt](https://nuxt.com/) is easier since Nuxt takes care of a 
 ## Installation
 
 ```bash
-yarn add pinia @pinia/nuxt
-# or with npm
-npm install pinia @pinia/nuxt
+# Using yarn
+yarn add pinia 
+yarn add --dev @pinia/nuxt
+
+# Using npm
+npm install pinia 
+npm install --save-dev @pinia/nuxt
+
+# Using pnpm
+pnpm add pinia
+pnpm add -D @pinia/nuxt
 ```
 
 :::tip


### PR DESCRIPTION
This pull request is intended to fix and update the `pinia` and `@pinia/nuxt` module installation by fixing the installation commands. 

1. fix: The `pinia` package should be installed as a regular dependency while the `@pinia/nuxt` module should be installed as a dev dependency.
2. update: I have added `pnpm` among the package managers to be used when installing `pinia` and `@pinia/nuxt` module.