### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/docs/ssr/index.md
+++ b/packages/docs/ssr/index.md
@@ -92,7 +92,7 @@ const pinia = createPinia()
 const app = createApp(App)
 app.use(pinia)
 
-// `isClient` depends on the environment, e.g. on Nuxt it's `process.client`
+// `isClient` depends on the environment, e.g. on Nuxt it's `import.meta.client`
 if (isClient) {
   pinia.state.value = JSON.parse(window.__pinia)
 }

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -8,7 +8,7 @@ useSomeStoreStore()
 
 // await useAsyncData('counter', () => counter.asyncIncrement().then(() => true))
 
-if (process.server) {
+if (import.meta.server) {
   counter.increment()
 }
 </script>

--- a/packages/nuxt/src/runtime/plugin.vue2.ts
+++ b/packages/nuxt/src/runtime/plugin.vue2.ts
@@ -16,7 +16,7 @@ export default (context: any, provide: any) => {
     Object.defineProperty(store, '$nuxt', { value: context })
   })
 
-  if (process.server) {
+  if (import.meta.server) {
     context.beforeNuxtRender((ctx: any) => {
       ctx.nuxtState.pinia = pinia.state.value
     })

--- a/packages/nuxt/src/runtime/plugin.vue3.ts
+++ b/packages/nuxt/src/runtime/plugin.vue3.ts
@@ -9,7 +9,7 @@ const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin({
     nuxtApp.vueApp.use(pinia)
     setActivePinia(pinia)
 
-    if (process.server) {
+    if (import.meta.server) {
       nuxtApp.payload.pinia = pinia.state.value
     } else if (nuxtApp.payload && nuxtApp.payload.pinia) {
       pinia.state.value = nuxtApp.payload.pinia


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)