### PR TITLE
chore: add getter double in playground demo-counter

### DIFF
--- a/packages/playground/src/stores/demo-counter.ts
+++ b/packages/playground/src/stores/demo-counter.ts
@@ -8,6 +8,9 @@ export const useCounter = defineStore('demo-counter', {
   state: () => ({
     n: 0,
   }),
+  getters: {
+    double: (state) => state.n * 2,
+  },
 })
 
 if (import.meta.hot) {


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

when I run playground, I found the code `<p>Counter :{{ counter.n }}. Double: {{ counter.double }}</p>`  in `DemoCounter.vue` , but in `demo-counter.ts` file, there is no `double`。so i think it's better to add `double` getter.