### PR TITLE
fix(types): storeToRefs with nested refs

### DIFF
--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -22,8 +22,8 @@ import type {
 } from './types'
 
 type ToComputedRefs<T> = {
-  [K in keyof T]: ToRef<T[K]> extends Ref<infer U>
-    ? ComputedRef<U>
+  [K in keyof T]: ToRef<T[K]> extends Ref
+    ? ComputedRef<T[K]>
     : ToRef<T[K]>
 }
 


### PR DESCRIPTION
Close #2658 

Fix: Return type of storeToRefs doesn't match runtime result if values are nested computed values #2658