### PR TITLE
feat(docs): ensure lowercase for the anchor slug

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -29,6 +29,8 @@ export const slugify = (str: string): string =>
     .replace(rSpecial, '-')
     // ensure it doesn't start with a number
     .replace(/^(\d)/, '_$1')
+    // ensure lowercase for the anchor slug
+    .toLowerCase()
 
 export const sharedConfig = defineConfig({
   title: 'Pinia',


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
In this pull request, I am sending a change that will ensure that the anchor slug will be using lowercase letters.

`https://pinia.vuejs.org/introduction.html#Introduction` with this change will be `https://pinia.vuejs.org/introduction.html#introduction`.