### PR TITLE
feat: add new method `destructureStore`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -89,6 +89,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
       { from: composables, name: 'acceptHMRUpdate' },
       { from: composables, name: 'usePinia' },
       { from: composables, name: 'storeToRefs' },
+      { from: composables, name: 'destructureStore' },
     ])
 
     if (!options.storesDirs) {

--- a/packages/pinia/__tests__/destructureStore.spec.ts
+++ b/packages/pinia/__tests__/destructureStore.spec.ts
@@ -1,0 +1,38 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+import {
+  createPinia,
+  defineStore,
+  destructureStore,
+  setActivePinia,
+} from '../src'
+
+describe('destructureStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const useCounterStore = defineStore('counter', {
+    state: () => ({
+      n: 1,
+    }),
+
+    getters: {
+      double: (state) => state.n * 2,
+    },
+
+    actions: {
+      increment(amount = 1) {
+        this.n += amount
+      },
+    },
+  })
+
+  it('test destructureStore', () => {
+    const { n, double, increment } = destructureStore(useCounterStore())
+
+    expect(n.value).toBe(1)
+    increment()
+    expect(n.value).toBe(2)
+    expect(double.value).toBe(4)
+  })
+})

--- a/packages/pinia/src/destructureStore.ts
+++ b/packages/pinia/src/destructureStore.ts
@@ -1,0 +1,15 @@
+import { StoreActions } from './store'
+import { StoreToRefs, storeToRefs } from './storeToRefs'
+import { Store } from './types'
+
+export function destructureStore<S extends Store>(
+  store: S
+): StoreToRefs<S> & StoreActions<S> {
+  const refs = storeToRefs(store)
+
+  const actions = Object.fromEntries(
+    Object.entries(store).filter(([, value]) => typeof value === 'function')
+  ) as StoreActions<S>
+
+  return { ...refs, ...actions }
+}

--- a/packages/pinia/src/destructureStore.ts
+++ b/packages/pinia/src/destructureStore.ts
@@ -1,15 +1,23 @@
+import { toRaw, toRef } from 'vue'
 import { StoreActions } from './store'
-import { StoreToRefs, storeToRefs } from './storeToRefs'
+import { StoreToRefs } from './storeToRefs'
 import { Store } from './types'
 
 export function destructureStore<S extends Store>(
   store: S
 ): StoreToRefs<S> & StoreActions<S> {
-  const refs = storeToRefs(store)
+  const _store = toRaw(store)
 
-  const actions = Object.fromEntries(
-    Object.entries(store).filter(([, value]) => typeof value === 'function')
-  ) as StoreActions<S>
+  return Object.entries(_store).reduce(
+    (acc, [key, value]) => {
+      if (typeof value === 'function') {
+        ;(acc as any)[key] = value
+      } else {
+        ;(acc as any)[key] = toRef(_store, key as keyof S)
+      }
 
-  return { ...refs, ...actions }
+      return acc
+    },
+    {} as StoreToRefs<S> & StoreActions<S>
+  )
 }

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -68,6 +68,7 @@ export {
 } from './mapHelpers'
 
 export { storeToRefs } from './storeToRefs'
+export { destructureStore } from './destructureStore'
 
 export type {
   MapStoresCustomization,


### PR DESCRIPTION
`storeToRefs` is cool but we cannot get any methods from the store.

Declaring a demo store

```js
const useCounterStore = defineStore('counter', {
  state: () => ({
    n: 1,
  }),

  getters: {
    double: (state) => state.n * 2,
  },

  actions: {
    increment(amount = 1) {
      this.n += amount
    },
  },
})
```

So to get reactive variables and functions from the store now we should use 3 lines.

```js
const counterStore = useCounterStore();
const { n, double } = storeToRefs(counterStore);
const { increment } = counterStore;
```

I've added a new method called `destructureStore` to destruct reactive variables and functions.

```js
const { n, double, increment } = destructureStore(useCounterStore())

// n and double are refs
```