### PR TITLE
feat(devtools): expose selected store as global variable

### DIFF
--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -217,8 +217,7 @@ export function registerPiniaDevtools(app: DevtoolsApp, pinia: Pinia) {
       })
 
       // Expose pinia instance as $pinia to window
-      const win = window as any
-      if (win) win.$pinia = pinia
+      globalThis.$pinia = pinia
 
       api.on.getInspectorState((payload) => {
         if (payload.app === app && payload.inspectorId === INSPECTOR_ID) {
@@ -235,8 +234,8 @@ export function registerPiniaDevtools(app: DevtoolsApp, pinia: Pinia) {
 
           if (inspectedStore) {
             // Expose selected store as $store to window
-            if (win && payload.nodeId !== PINIA_ROOT_ID)
-              win.$store = toRaw(inspectedStore)
+            if (payload.nodeId !== PINIA_ROOT_ID)
+              globalThis.$store = toRaw(inspectedStore as StoreGeneric)
             payload.state = formatStoreForInspectorState(inspectedStore)
           }
         }
@@ -593,4 +592,15 @@ export function devtoolsPlugin<
     // FIXME: is there a way to allow the assignment from Store<Id, S, G, A> to StoreGeneric?
     store as StoreGeneric
   )
+}
+
+declare global {
+  /**
+   * Exposes the `pinia` instance when Devtools are opened.
+   */
+  var $pinia: Pinia | undefined
+  /**
+   * Exposes the current store when Devtools are opened.
+   */
+  var $store: StoreGeneric | undefined
 }

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -230,6 +230,12 @@ export function registerPiniaDevtools(app: DevtoolsApp, pinia: Pinia) {
           }
 
           if (inspectedStore) {
+            const win = window as any
+            if (win) {
+              win.$p = payload.nodeId === PINIA_ROOT_ID
+                ? inspectedStore
+                : toRaw(inspectedStore)
+            }
             payload.state = formatStoreForInspectorState(inspectedStore)
           }
         }

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -216,6 +216,10 @@ export function registerPiniaDevtools(app: DevtoolsApp, pinia: Pinia) {
         }
       })
 
+      // Expose pinia instance as $pinia to window
+      const win = window as any
+      if (win) win.$pinia = pinia
+
       api.on.getInspectorState((payload) => {
         if (payload.app === app && payload.inspectorId === INSPECTOR_ID) {
           const inspectedStore =
@@ -230,12 +234,9 @@ export function registerPiniaDevtools(app: DevtoolsApp, pinia: Pinia) {
           }
 
           if (inspectedStore) {
-            const win = window as any
-            if (win) {
-              win.$p = payload.nodeId === PINIA_ROOT_ID
-                ? inspectedStore
-                : toRaw(inspectedStore)
-            }
+            // Expose selected store as $store to window
+            if (win && payload.nodeId !== PINIA_ROOT_ID)
+              win.$store = toRaw(inspectedStore)
             payload.state = formatStoreForInspectorState(inspectedStore)
           }
         }


### PR DESCRIPTION
Refs: #732

Clicking on a store in pinia devtools should make it available as a global variable


https://github.com/vuejs/pinia/assets/22590005/1b6fc1dd-9704-4bea-95cc-8def5f5bbc98

