### PR TITLE
docs: fix case sensitive links

### DIFF
--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -42,7 +42,7 @@ const useY = defineStore('y', () => {
 
 ## Nested Stores
 
-Note that if one store uses another store, you can directly import and call the `useStore()` function within _actions_ and _getters_. Then you can interact with the store just like you would from within a Vue component. See [Shared Getters](#shared-getters) and [Shared Actions](#shared-actions).
+Note that if one store uses another store, you can directly import and call the `useStore()` function within _actions_ and _getters_. Then you can interact with the store just like you would from within a Vue component. See [Shared Getters](#Shared-Getters) and [Shared Actions](#Shared-Actions).
 
 When it comes to _setup stores_, you can simply use one of the stores **at the top** of the store function:
 


### PR DESCRIPTION
The "Shared-Getters" and "Shared-Actions" links need to be capitalised to work - this is due to the markdown processor pinia uses giving them capitalised IDs (the "Shared Actions" heading is a ``<h2 id=Shared-Actions>`` rather than ``<h2 id=shared-actions>``

The proper fix for this would probably be to have the relevant markdown processor give headings lowercase IDs as that is more conventional afaik - this PR is meant as a stopgap to at least have the two links fixed in this commit work.