### PR TITLE
fix(types): breaking type with auto imported components with Vue3

### DIFF
--- a/packages/pinia/src/globalExtensions.ts
+++ b/packages/pinia/src/globalExtensions.ts
@@ -41,6 +41,7 @@ declare module 'vue/types/options' {
  */
 // @ts-ignore: works on Vue 3, fails in Vue 2
 declare module 'vue' {
+  export interface GlobalComponents {}
   export interface ComponentCustomProperties {
     /**
      * Access to the application's Pinia


### PR DESCRIPTION
### Related Issue

#2728 #2729 

### Reproduction

```sh
git clone https://github.com/Bernankez/pinia-types-repro.git
cd pinia-types-repro
pnpm install
```
Open `src/main.ts` and following the instructions.

### Environment

Node v20.15.0
VSCode v1.92.0
Vue.volar v2.0.28

### Additional information

I found that the import order of `router`, `App` and `pinia` can effect the `RouterView` type display in VSCode. If the `router` is imported first, then regardless of the order of `App` and `pinia`, the type of `RouterView` is always correct. If imported in the order of `App`, `pinia`, `router`, the type of `RouterView` will also be correct. However, if imported in the order of `pinia`, `App`, `router`, the type of `RouterView` will be `any`. I found that as mentioned in [this PR](https://github.com/unplugin/unplugin-auto-import/pull/469), adding an empty GlobalComponents export can fix this issue, regardless of the import order. I'm not sure if it's a pinia issue, so temporarily mark it as a draft.