### PR TITLE
docs: More detailed explanation of `inject()` usage in `defineStore()`

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -99,6 +99,10 @@ export const useSearchFilters = defineStore('search-filters', () => {
 ```
 
 :::warning
+The injected properties must be **provided globally**. Component-provided properties cannot be accessed within the `defineStore()` function and will return `undefined` if injected.
+
+If you are using Nuxt, use `useNuxtApp().vueApp.provide('appProvided', 'value')` to provide a property globally.
+
 Do not return properties like `route` or `appProvided` (from the example above) as they do not belong to the store itself and you can directly access them within components with `useRoute()` and `inject('appProvided')`.
 :::
 

--- a/packages/docs/zh/core-concepts/index.md
+++ b/packages/docs/zh/core-concepts/index.md
@@ -97,6 +97,10 @@ export const useSearchFilters = defineStore('search-filters', () => {
 ```
 
 :::warning
+使用 `inject()` 注入的属性必须是**全局提供的**，组件提供的属性在 `defineStore()` 里无法被访问，若尝试注入这些属性，将会得到 `undefined` 。
+
+如果你使用 Nuxt，你可以使用 `useNuxtApp().vueApp.provide('appProvided', 'value')` 来全局提供一个属性。
+
 不要返回像 `route` 或 `appProvided` (上例中)之类的属性，因为它们不属于 store，而且你可以在组件中直接用 `useRoute()` 和 `inject('appProvided')` 访问。
 :::
 


### PR DESCRIPTION
According to vuejs/core#11602, I believe users may confuse **globally provided properties** with **component-provided properties** when using Pinia. Therefore, I suggest emphasizing this in the documentation and including the implementation with Nuxt.