### PR TITLE
chore: add `#__NO_SIDE_EFFECTS__` notation to `defineStore`

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -870,6 +870,8 @@ export function defineStore<Id extends string, SS>(
   _ExtractGettersFromSetupStore<SS>,
   _ExtractActionsFromSetupStore<SS>
 >
+
+/*#__NO_SIDE_EFFECTS__*/
 export function defineStore(
   // TODO: add proper types from above
   idOrOptions: any,

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -870,7 +870,7 @@ export function defineStore<Id extends string, SS>(
   _ExtractGettersFromSetupStore<SS>,
   _ExtractActionsFromSetupStore<SS>
 >
-
+// improves tree shaking
 /*#__NO_SIDE_EFFECTS__*/
 export function defineStore(
   // TODO: add proper types from above


### PR DESCRIPTION
Fix #2738

In `defineStore`, certain behaviors of `createSetupStore` and `createOptionsStore` might prevent the bundler from performing static analysis to determine whether there are any side effects.

Therefore, in this PR, the `defineStore` function is marked as having no side effects, enabling the bundler to tree-shake stores that are not used after being defined.

## References
https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md
https://github.com/rollup/rollup/pull/5024