### PR TITLE
Docs: Migrate mockedStore typings to vitest v2

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -191,7 +191,7 @@ function mockedStore<TStoreDef extends () => unknown>(
           ...args: infer Args
         ) => infer ReturnT
           ? // 👇 depends on your testing framework
-            Mock<Args, ReturnT>
+            Mock<(args: Args) => ReturnT>
           : Actions[K]
       }
     > & {


### PR DESCRIPTION
Update docs to migrate the typings of `mockedStore` to the changes of >vitest@2.0.0:

see:
https://vitest.dev/guide/migration#simplified-generic-types-of-mock-functions-e-g-vi-fn-t-mock-t
https://github.com/vitest-dev/vitest/releases/tag/v2.0.0

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
