### PR TITLE
docs: Nuxt 2 --> 3

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -62,7 +62,7 @@ await useAsyncData('user', () => store.fetchUser().then(() => true))
 
 ::: tip
 
-If you want to use a store outside of `setup()`, remember to pass the `$pinia` object to `useStore()`, for the reasons alluded to [here](https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps).
+If you want to use a store outside of `setup()`, remember to pass the `$pinia` instance to `useStore()`, for the reasons alluded to [here](https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps).
 
 ```js
 import { useStore } from '~/stores/myStore'

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -62,18 +62,17 @@ await useAsyncData('user', () => store.fetchUser().then(() => true))
 
 ::: tip
 
-If you want to use a store outside of `setup()`, remember to pass the `$pinia` instance to `useStore()`, for the reasons alluded to [here](https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps).
+If you want to use a store outside of `setup()` or an _injection aware_ context (e.g. Navigation guards, other stores, Nuxt Middlewares, etc), remember to pass the `pinia` instance to `useStore()`, for the reasons alluded to [here](https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps). Retrieving the `pinia` instance might vary.
 
-```js
+```ts
 import { useStore } from '~/stores/myStore'
-const store = useStore(useNuxtApp().$pinia);
 
-onMounted(() => {
-  if (window.innerWidth < 900) {
-    store.doAction()
-  }
-});
+// this line is usually inside a function that is able to retrieve
+// the pinia instance
+const store = useStore(pinia)
 ```
+
+Fortunately, most of the time you **don't need to go through this hassle**.
 
 :::
 

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -62,16 +62,17 @@ await useAsyncData('user', () => store.fetchUser().then(() => true))
 
 ::: tip
 
-If you want to use a store outside of `setup()`, remember to pass the `pinia` object to `useStore()`. We added it to [the context](https://nuxtjs.org/docs/2.x/internals-glossary/context) so you have access to it in `asyncData()` and `fetch()`:
+If you want to use a store outside of `setup()`, remember to pass the `$pinia` object to `useStore()`, for the reasons alluded to [here](https://pinia.vuejs.org/core-concepts/outside-component-usage.html#SSR-Apps).
 
 ```js
 import { useStore } from '~/stores/myStore'
+const store = useStore(useNuxtApp().$pinia);
 
-export default {
-  asyncData({ $pinia }) {
-    const store = useStore($pinia)
-  },
-}
+onMounted(() => {
+  if (window.innerWidth < 900) {
+    store.doAction()
+  }
+});
 ```
 
 :::


### PR DESCRIPTION
Replace tip that was relevant to Nuxt 2 with the equivalent syntax for Nuxt 3.

I'm not sure whether this is in fact the intended usage pattern / syntax for Nuxt 3, but I think what I've written is an improvement over the status quo, since at least it works.

If this PR results in, or is deemed as, a definitive answer to [this question](https://github.com/vuejs/pinia/discussions/2245), it may resolve that discussion.