### PR TITLE
fix(types): Don't double UnwrapRef in setup stores

### DIFF
--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -583,7 +583,7 @@ export type _UnwrapAll<SS> = { [K in keyof SS]: UnwrapRef<SS[K]> }
 export type _ExtractStateFromSetupStore<SS> = SS extends undefined | void
   ? {}
   : _ExtractStateFromSetupStore_Keys<SS> extends keyof SS
-    ? _UnwrapAll<Pick<SS, _ExtractStateFromSetupStore_Keys<SS>>>
+    ? Pick<SS, _ExtractStateFromSetupStore_Keys<SS>>
     : never
 
 /**

--- a/packages/pinia/test-dts/state.test-d.ts
+++ b/packages/pinia/test-dts/state.test-d.ts
@@ -1,4 +1,4 @@
-import { computed, ref, shallowRef } from 'vue'
+import { computed, Ref, ref, shallowRef } from 'vue'
 import { defineStore, expectType } from './'
 
 const name = ref('Eduardo')
@@ -19,6 +19,7 @@ const useStore = defineStore({
     counter,
     aRef: ref(0),
     aShallowRef: shallowRef({ msg: 'hi' }),
+    anotherShallowRef: shallowRef({ aRef: ref('hello') }),
   }),
 
   getters: {
@@ -67,6 +68,8 @@ expectType<number>(store.fromARef)
 
 expectType<{ msg: string }>(store.aShallowRef)
 expectType<{ msg: string }>(store.$state.aShallowRef)
+expectType<{ aRef: Ref<string> }>(store.anotherShallowRef)
+expectType<{ aRef: Ref<string> }>(store.$state.anotherShallowRef)
 
 const onlyState = defineStore({
   id: 'main',
@@ -83,3 +86,11 @@ onlyState.$patch((state) => {
   expectType<string>(state.some)
   expectType<string>(state.name)
 })
+
+const useSetupStore = defineStore('composition', () => ({
+  anotherShallowRef: shallowRef({ aRef: ref('hello') }),
+}))
+
+const setupStore = useSetupStore()
+expectType<{ aRef: Ref<string> }>(setupStore.anotherShallowRef)
+expectType<{ aRef: Ref<string> }>(setupStore.$state.anotherShallowRef)


### PR DESCRIPTION
fixes #2770

Without this change for setup stores `UnwrapRef` is applied to state type twice. 

First time after defineStore infers the `SS` type parameter and passes it to `_ExtractStateFromSetupStore`: https://github.com/vuejs/pinia/blob/3c8782ee19fcbf16392b061b84caac4b47722414/packages/pinia/src/types.ts#L586

Then the result of `_ExtractStateFromSetupStore<SS>` is passed to `StoreDefinition` interface, which passes it to `Store` type, which does https://github.com/vuejs/pinia/blob/3c8782ee19fcbf16392b061b84caac4b47722414/packages/pinia/src/types.ts#L470

First unwrap call reduces state type
```ts
// from
{ foo: ShallowRef<{ bar: Ref<string> }> }
// to 
{ foo: { bar: Ref<string> } }
```

Second unwrap call reduces it further producing type that doesn't match the runtime value

```ts 
// from
{ foo: { bar: Ref<string> } }
// to the incorrect
{ foo: { bar: string } }
```