### PR TITLE
feat(hmr): extend `acceptHMRUpdate` to allow for cleaning up side effects of existing store

### DIFF
--- a/packages/docs/cookbook/hot-module-replacement.md
+++ b/packages/docs/cookbook/hot-module-replacement.md
@@ -2,8 +2,8 @@
 
 Pinia supports Hot Module replacement so you can edit your stores and interact with them directly in your app without reloading the page, allowing you to keep the existing state, add, or even remove state, actions, and getters.
 
-At the moment, only [Vite](https://vitejs.dev/guide/api-hmr.html#hmr-api) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`). 
-You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `cart.js`, and `chat.js`, you will have to add (and adapt) this after the creation of the _store definition_:
+At the moment, only [Vite](https://vitejs.dev/guide/api-hmr.html#hmr-api) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`).
+You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `chat.js`, and `scroll.js`, you will have to add (and adapt) this after the creation of the _store definition_:
 
 ```js
 // auth.js
@@ -16,5 +16,43 @@ export const useAuth = defineStore('auth', {
 // make sure to pass the right store definition, `useAuth` in this case.
 if (import.meta.hot) {
   import.meta.hot.accept(acceptHMRUpdate(useAuth, import.meta.hot))
+}
+```
+
+You can pass a cleanup function as an optional third argument in order to clean up side effects of the existing store before initializing the new store. This is useful if you have event listeners or other side effects that need to be cleaned up.
+
+```js
+// scroll.js
+import { defineStore, acceptHMRUpdate } from 'pinia'
+import { ref } from 'vue'
+
+export const useScroll = defineStore('scroll', () => {
+  const scrollTop = ref(window.scrollY)
+
+  function onScroll () {
+    scrollTop.value = window.scrollY
+  }
+
+  function trackScroll () {
+    window.addEventListener('scroll', onScroll, { passive: true })
+  }
+
+  trackScroll()
+
+  function $cleanUp () {
+    window.removeEventListener('scroll', onScroll)
+  }
+
+  return {
+    scrollTop,
+    trackScroll,
+    $cleanUp,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useScroll, import.meta.hot, (existingStore) => {
+    existingStore.$cleanUp()
+  }))
 }
 ```

--- a/packages/playground/src/stores/scroll.ts
+++ b/packages/playground/src/stores/scroll.ts
@@ -1,0 +1,43 @@
+import { defineStore, acceptHMRUpdate } from 'pinia'
+import { onScopeDispose, ref } from 'vue'
+
+export const useScroll = defineStore('scroll', () => {
+  const scrollTop = ref(window.scrollY)
+
+  function onScroll() {
+    scrollTop.value = window.scrollY
+  }
+
+  function trackScroll() {
+    window.addEventListener('scroll', onScroll, { passive: true })
+  }
+
+  trackScroll()
+
+  function $cleanUp() {
+    console.log('Cleaning up old scroll event listeners')
+    window.removeEventListener('scroll', onScroll)
+  }
+
+  // if someone wants the scroll tracking only to happen on a certain route,
+  // one can dispose the store before leaving the route.
+  onScopeDispose(() => {
+    console.log('onScopeDispose')
+    $cleanUp()
+  })
+
+  return {
+    scrollTop,
+    trackScroll,
+    $cleanUp,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useScroll, import.meta.hot, (existingStore) => {
+      console.log('HMR update')
+      existingStore.$cleanUp()
+    })
+  )
+}

--- a/packages/playground/src/views/ScrollStore.vue
+++ b/packages/playground/src/views/ScrollStore.vue
@@ -1,0 +1,38 @@
+<script lang="ts" setup>
+import { onBeforeUnmount, onMounted } from 'vue'
+import { getActivePinia } from 'pinia';
+import { onBeforeRouteLeave } from 'vue-router';
+import { useScroll } from '../stores/scroll'
+
+const bodyStyle = document.body.style
+const appStyle = document.getElementById('app')!.style
+
+const scrollStore = useScroll()
+
+onMounted(() => {
+  bodyStyle.setProperty('height', '300vh')
+  appStyle.setProperty('position', 'sticky')
+  appStyle.setProperty('top', '0')
+})
+
+onBeforeUnmount(() => {
+  bodyStyle.removeProperty('height')
+  appStyle.removeProperty('position')
+  appStyle.removeProperty('top')
+})
+
+onBeforeRouteLeave(() => {
+  scrollStore.$dispose()
+  const pinia = getActivePinia()
+  delete pinia!.state.value[scrollStore.$id]
+})
+</script>
+
+<template>
+  <div style="position: sticky; top: 0;">
+    <h2>Scroll Store</h2>
+    <p><strong>Scroll top:</strong> {{ scrollStore.scrollTop }}</p>
+    <p>During development, after saving changes in <code>/stores/scroll.ts</code>, the <code>acceptHMRUpdate</code> function is configured to run the <code>$cleanUp</code> function on the existing store just before the new store is initialized.</p>
+    <p>You can only verify this manually by making changes in <code>/stores/scroll.ts</code> and checking what scroll event listeners are on the <code>&lt;html&gt;</code> element. There should always only be one.</p>
+  </div>
+</template>


### PR DESCRIPTION
### Changes
This PR adds to possibility of passing a cleanup function as an optional third argument to `acceptHMRUpdate`. This cleanup function can be used to clean up side effects of the existing store before initializing the new store. This is useful if you have event listeners or other side effects that need to be cleaned up in the old store.

This solves a non-trivial case. Usually, having side effects inside a Pinia store is probably not such a great idea. However, it happens, and if it does, we need to provide a way to make sure those side effects can be properly cleaned up during HMR.

Let's say you have an app that relies on a lot of event listeners, and you want to manage them centrally and close to some global state. If there isn't an obvious Vue component to add and remove all these event listeners, you might choose to manage these event listeners in a Pinia store. While working on this Pinia store, you might need to clean up some of those event listeners, before HMR replaces the existing store with the new one. We can use `onScopeDispose` to run some code when the store is disposed, but nothing is disposed when HMR swaps the stores, so we can't use that mechanism here. For better control over HMR, we need a way to talk to the existing store, just before it gets replaced. This PR provides that mechanism.

### To do
- **Tests:** I couldn't find a way to properly test this. If someone can assist with that, that would be nice! I've manually tested using the playground (see the `/scroll-store` route).
- **Translations:** I updated the English docs about HMR, but the Chinese version needs to be updated as well.
- **Explore alternatives:** I can imagine something like an `onBeforeHMRReplace` hook being a viable alternative. A user would need to call `onBeforeHMRReplace` in a setup store, just like with `onScopeDispose`. It would probably require us to detect and register any called `onBeforeHMRReplace` hooks during the setup phase (store initialization) and manually trigger their callbacks in `acceptHMRUpdate`.

### Example (taken from the modified docs)
```js
// scroll.js
import { defineStore, acceptHMRUpdate } from 'pinia'
import { ref } from 'vue'

export const useScroll = defineStore('scroll', () => {
  const scrollTop = ref(window.scrollY)

  function onScroll () {
    scrollTop.value = window.scrollY
  }

  function trackScroll () {
    window.addEventListener('scroll', onScroll, { passive: true })
  }

  trackScroll()

  function $cleanUp () {
    window.removeEventListener('scroll', onScroll)
  }

  return {
    scrollTop,
    trackScroll,
    $cleanUp,
  }
})

if (import.meta.hot) {
  import.meta.hot.accept(acceptHMRUpdate(useScroll, import.meta.hot, (existingStore) => {
    existingStore.$cleanUp()
  }))
}
```