### PR TITLE
fix: reference the store directly in storeToRefs to ensure correct reactivity after HMR

### DIFF
--- a/packages/pinia/__tests__/storeToRefs.spec.ts
+++ b/packages/pinia/__tests__/storeToRefs.spec.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest'
 import { computed, reactive, ref, ToRefs } from 'vue'
 import { createPinia, defineStore, setActivePinia, storeToRefs } from '../src'
+import { set } from 'vue-demi'
 
 describe('storeToRefs', () => {
   beforeEach(() => {
@@ -168,6 +169,25 @@ describe('storeToRefs', () => {
     const refs = storeToRefs(useStore())
     refs.double.value = 4
     expect(refs.n.value).toBe(2)
+  })
+
+  it('keep reactivity', () => {
+    const store = defineStore('a', () => {
+      const n = ref(0)
+      const double = computed(() => n.value * 2)
+      return { n, double }
+    })()
+
+    const { double } = storeToRefs(store)
+
+    // Assuming HMR operation
+    set(
+      store,
+      'double',
+      computed(() => 1)
+    )
+
+    expect(double.value).toEqual(1)
   })
 
   tds(() => {

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -94,11 +94,11 @@ export function storeToRefs<SS extends StoreGeneric>(
     // @ts-expect-error: toRefs include methods and others
     return toRefs(store)
   } else {
-    store = toRaw(store)
+    const rawStore = toRaw(store)
 
     const refs = {} as StoreToRefs<SS>
-    for (const key in store) {
-      const value = store[key]
+    for (const key in rawStore) {
+      const value = rawStore[key]
       if (isRef(value) || isReactive(value)) {
         // @ts-expect-error: the key is state or getter
         refs[key] =


### PR DESCRIPTION
fix: https://github.com/vuejs/pinia/issues/2779

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

I have a store referenced with toRaw, so it doesn’t update when it changes. 
By referencing a store that is not wrapped in toRaw, it updates as expected. 
If it is necessary to reference something wrapped in toRaw, I apologize.
