### PR TITLE
Update actions type in mockStore helper method

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -191,7 +191,7 @@ function mockedStore<TStoreDef extends () => unknown>(
           ...args: infer Args
         ) => infer ReturnT
           ? // 👇 depends on your testing framework
-            Mock<Args, ReturnT>
+            Mock<Actions[K]>
           : Actions[K]
       }
     > & {


### PR DESCRIPTION
I recently tried the `mockedStore` helper function to have rich types on the mocked actions of a store, but it **failed** to compile.

I managed to use the correct type for **Vitest** and tested it's working correctly :)