### PR TITLE
fix(nuxt): ensure payload plugin declaration is generated

### DIFF
--- a/packages/nuxt/src/runtime/payload-plugin.ts
+++ b/packages/nuxt/src/runtime/payload-plugin.ts
@@ -3,6 +3,7 @@ import {
   definePayloadReducer,
   definePayloadReviver,
 } from '#imports'
+import {} from 'nuxt/app'
 import { shouldHydrate } from 'pinia'
 
 /**


### PR DESCRIPTION
follow-up on https://github.com/vuejs/pinia/commit/e645fc12ea115a2d2cc395ad83e4cc3df350c4ea

currently this emits an empty plugin declaration file - you can see the following warning in the build:

```
src/runtime/payload-plugin.ts(11,7): error TS2742: The inferred type of 'payloadPlugin' cannot be named without a reference to '.pnpm/nuxt@3.13.2_@parcel+watcher@2.4.1_@types+node@22.7.4_encoding@0.1.13_ioredis@5.4.1_magicast@0_xnetk5q47sjylsz3dxwz7c7qre/node_modules/nuxt/app'. This is likely not portable. A type annotation is necessary.
```

see https://github.com/nuxt/module-builder/issues/141#issuecomment-2078248248