### PR TITLE
feat(nuxt): supports automatic import of stores from extend layers

### DIFF
--- a/packages/nuxt/playground/play-extends-layer/app.vue
+++ b/packages/nuxt/playground/play-extends-layer/app.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+const counter = useCounter()
+
+useTestStore()
+useSomeStoreStore()
+</script>

--- a/packages/nuxt/playground/play-extends-layer/nuxt.config.ts
+++ b/packages/nuxt/playground/play-extends-layer/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  extends: ['..'],
+
+  devtools: { enabled: true },
+
+  compatibilityDate: '2024-09-26',
+})

--- a/packages/nuxt/playground/play-extends-layer/package.json
+++ b/packages/nuxt/playground/play-extends-layer/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "pinia-nuxt-playground-extends-layer",
+  "scripts": {
+    "dev": "nuxt dev"
+  }
+}

--- a/packages/nuxt/playground/play-extends-layer/tsconfig.json
+++ b/packages/nuxt/playground/play-extends-layer/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/packages/nuxt/playground/tsconfig.json
+++ b/packages/nuxt/playground/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "exclude": ["./play-extends-layer"]
 }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -101,6 +101,10 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     if (options.storesDirs) {
       for (const storeDir of options.storesDirs) {
         addImportsDir(resolve(nuxt.options.rootDir, storeDir))
+
+        for (const layer of nuxt.options._layers) {
+          addImportsDir(resolve(layer.config.rootDir, storeDir))
+        }
       }
     }
   },


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

When I install pinia in a nuxt ***layer*** and create `stores` folder, and then I extend this ***layer*** in another nuxt application, I find that the `stores` are not automatically imported.

### What this PR does:

When addImportsDir, consider the nuxt layers also.

#### Refer:

[Pinia autoImports for nuxt](https://pinia.vuejs.org/ssr/nuxt.html#Auto-imports)

[Nuxt layers](https://nuxt.com/docs/getting-started/layers)