### PR TITLE
update: vueschool top banner script affiliate name to pinia

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -96,7 +96,7 @@ export const sharedConfig = defineConfig({
     [
       'script',
       {
-        src: 'https://vueschool.io/banner.js?affiliate=vuerouter&type=top',
+        src: 'https://vueschool.io/banner.js?affiliate=pinia&type=top',
         // @ts-expect-error: vitepress bug
         async: true,
         type: 'text/javascript',


### PR DESCRIPTION
This PR is a request from the Vue School Team to update the Vue School Top Banner affiliate name to **pinia** to help run banners more efficiently as we have updated some parts of our banner system.
Thank you.

