### PR TITLE
fix: avoid npm bug when resolving optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,6 @@ A few notes about the project and possible questions:
 npm install pinia
 ```
 
-If you are using Vue <2.7, make sure to install latest `@vue/composition-api`:
-
-```bash
-npm install pinia @vue/composition-api
-```
-
 ## Usage
 
 ### Install the plugin

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -77,15 +77,11 @@
     "vue-demi": "^0.14.10"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^1.4.0",
     "typescript": ">=4.4.4",
-    "vue": "^2.6.14 || ^3.5.11"
+    "vue": "^2.7.0 || ^3.5.11"
   },
   "peerDependenciesMeta": {
     "typescript": {
-      "optional": true
-    },
-    "@vue/composition-api": {
       "optional": true
     }
   },

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -127,8 +127,10 @@ const skipHydrateMap = /*#__PURE__*/ new WeakMap<any, any>()
  * @returns obj
  */
 export function skipHydrate<T = any>(obj: T): T {
+  // TODO: check if can be simplified for Vue 2.7
   return isVue2
-    ? // in @vue/composition-api, the refs are sealed so defineProperty doesn't work...
+    ? // in @vue/composition-api (no needed in Vue 2.7),
+      // the refs are sealed so defineProperty doesn't work...
       /* istanbul ignore next */ skipHydrateMap.set(obj, 1) && obj
     : Object.defineProperty(obj, skipHydrateSymbol, {})
 }

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -117,7 +117,6 @@ function mergeReactiveObjects<
 const skipHydrateSymbol = __DEV__
   ? Symbol('pinia:skipHydration')
   : /* istanbul ignore next */ Symbol()
-const skipHydrateMap = /*#__PURE__*/ new WeakMap<any, any>()
 
 /**
  * Tells Pinia to skip the hydration process of a given object. This is useful in setup stores (only) when you return a
@@ -127,12 +126,7 @@ const skipHydrateMap = /*#__PURE__*/ new WeakMap<any, any>()
  * @returns obj
  */
 export function skipHydrate<T = any>(obj: T): T {
-  // TODO: check if can be simplified for Vue 2.7
-  return isVue2
-    ? // in @vue/composition-api (no needed in Vue 2.7),
-      // the refs are sealed so defineProperty doesn't work...
-      /* istanbul ignore next */ skipHydrateMap.set(obj, 1) && obj
-    : Object.defineProperty(obj, skipHydrateSymbol, {})
+  return Object.defineProperty(obj, skipHydrateSymbol, {})
 }
 
 /**
@@ -142,9 +136,7 @@ export function skipHydrate<T = any>(obj: T): T {
  * @returns true if `obj` should be hydrated
  */
 export function shouldHydrate(obj: any) {
-  return isVue2
-    ? /* istanbul ignore next */ !skipHydrateMap.has(obj)
-    : !isPlainObject(obj) || !obj.hasOwnProperty(skipHydrateSymbol)
+  return !isPlainObject(obj) || !obj.hasOwnProperty(skipHydrateSymbol)
 }
 
 const { assign } = Object

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,9 +191,6 @@ importers:
 
   packages/pinia:
     dependencies:
-      '@vue/composition-api':
-        specifier: ^1.4.0
-        version: 1.7.2(vue@3.5.13(typescript@5.6.3))
       '@vue/devtools-api':
         specifier: ^6.6.3
         version: 6.6.4
@@ -201,7 +198,7 @@ importers:
         specifier: '>=4.4.4'
         version: 5.6.3
       vue:
-        specifier: ^2.6.14 || ^3.5.11
+        specifier: ^2.7.0 || ^3.5.11
         version: 3.5.13(typescript@5.6.3)
       vue-demi:
         specifier: ^0.14.10
@@ -7013,6 +7010,7 @@ snapshots:
   '@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       vue: 3.5.13(typescript@5.6.3)
+    optional: true
 
   '@vue/devtools-api@6.6.4': {}
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -96,7 +96,6 @@ function createConfig(buildName, output, plugins = []) {
   output.globals = {
     'vue-demi': 'VueDemi',
     vue: 'Vue',
-    '@vue/composition-api': 'vueCompositionApi',
   }
 
   const isProductionBuild = /\.prod\.[cm]?js$/.test(output.file)
@@ -127,7 +126,7 @@ function createConfig(buildName, output, plugins = []) {
   // during a single build.
   hasTSChecked = true
 
-  const external = ['vue-demi', 'vue', '@vue/composition-api']
+  const external = ['vue-demi', 'vue']
   if (
     !isGlobalBuild &&
     // pinia.prod.cjs should not require `@vue/devtools-api` (like Vue)


### PR DESCRIPTION
this makes the package require vue 2.7 but has no code changes

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
