### PR TITLE
fix: allow module to install pinia alongside

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -46,7 +46,9 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l @pinia/nuxt -r 1"
   },
   "dependencies": {
-    "@nuxt/kit": "^3.14.1592",
+    "@nuxt/kit": "^3.14.1592"
+  },
+  "peerDependencies": {
     "pinia": "workspace:^"
   },
   "devDependencies": {
@@ -54,6 +56,7 @@
     "@nuxt/schema": "^3.14.1592",
     "@nuxt/test-utils": "^3.14.4",
     "nuxt": "^3.14.1592",
+    "pinia": "workspace:^",
     "typescript": "^5.6.3",
     "vue-tsc": "^2.1.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       '@nuxt/kit':
         specifier: ^3.9.0
         version: 3.14.1592(magicast@0.3.5)(rollup@4.27.3)
-      pinia:
-        specifier: workspace:^
-        version: link:../pinia
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^0.8.4
@@ -154,6 +151,9 @@ importers:
       nuxt:
         specifier: ^3.14.1592
         version: 3.14.1592(@parcel/watcher@2.5.0)(@types/node@22.9.1)(encoding@0.1.13)(ioredis@5.4.1)(magicast@0.3.5)(rollup@4.27.3)(terser@5.36.0)(typescript@5.6.3)(vite@5.4.11(@types/node@22.9.1)(terser@5.36.0))(vue-tsc@2.1.10(typescript@5.6.3))
+      pinia:
+        specifier: workspace:^
+        version: link:../pinia
       typescript:
         specifier: ^5.6.3
         version: 5.6.3


### PR DESCRIPTION
This should allow the nuxt module to install pinia if needed

Fix #2820

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
