### PR TITLE
chore(playground): update dependencies and init

### DIFF
--- a/packages/online-playground/README.md
+++ b/packages/online-playground/README.md
@@ -1,13 +1,13 @@
 # SFC Playground
 
-This is continuously deployed at [https://play.vuejs.org](https://play.vuejs.org).
+This is continuously deployed at [https://play.pinia.vuejs.org/](https://play.pinia.vuejs.org).
 
 ## Run Locally in Dev
 
 In repo root:
 
 ```sh
-pnpm dev-sfc
+pnpm -F @pinia/online-playground dev
 ```
 
 ## Build for Prod
@@ -15,5 +15,11 @@ pnpm dev-sfc
 In repo root
 
 ```sh
-pnpm build-sfc-playground
+pnpm -F @pinia/online-playground build
+```
+
+Preview the build
+
+```sh
+pnpm -F @pinia/online-playground serve
 ```

--- a/packages/online-playground/package.json
+++ b/packages/online-playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pinia/playground",
+  "name": "@pinia/online-playground",
   "version": "0.0.0",
   "type": "module",
   "private": true,
@@ -11,10 +11,11 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
     "execa": "^9.5.1",
+    "typescript": "^5.7.2",
     "vite": "^6.0.2"
   },
   "dependencies": {
-    "@vue/repl": "^3.0.0",
+    "@vue/repl": "^4.4.2",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "pinia": "workspace:*",

--- a/packages/online-playground/src/Header.vue
+++ b/packages/online-playground/src/Header.vue
@@ -25,7 +25,7 @@ const piniaVersion = inject(PiniaVersionKey)!
 
 async function setVueVersion(v: string) {
   vueVersion.value = `loading...`
-  await store.setVueVersion(v)
+  store.vueVersion = v
   vueVersion.value = `v${v}`
 }
 
@@ -59,7 +59,7 @@ function toggleDark() {
       </a>
     </h1>
     <div class="links">
-      <VersionSelect v-model="store.state.typescriptVersion" pkg="typescript">
+      <VersionSelect v-model="store.typescriptVersion" pkg="typescript">
         <template #label>
           <img src="/logo-ts.svg" alt="TypeScript" class="version-logo" />
         </template>

--- a/packages/online-playground/src/defaults.ts
+++ b/packages/online-playground/src/defaults.ts
@@ -2,7 +2,7 @@ import { InjectionKey, Ref } from 'vue'
 
 export const AppVue = `
 <script setup lang="ts">
-import { useStore } from './counter.ts'
+import { useStore } from './counter'
 
 const store = useStore()
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,25 +116,25 @@ importers:
     dependencies:
       '@chenfengyuan/vue-countdown':
         specifier: ^2.1.2
-        version: 2.1.2(vue@3.5.13(typescript@5.6.3))
+        version: 2.1.2(vue@3.5.13(typescript@5.7.2))
       '@vueuse/core':
         specifier: ^12.0.0
-        version: 12.0.0(typescript@5.6.3)
+        version: 12.0.0(typescript@5.7.2)
       pinia:
         specifier: workspace:*
         version: link:../pinia
       typedoc-vitepress-theme:
         specifier: ^1.1.1
-        version: 1.1.1(typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.6.3)))
+        version: 1.1.1(typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.7.2)))
       vitepress:
         specifier: 1.5.0
-        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3)
+        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.7.2)
       vitepress-translation-helper:
         specifier: ^0.2.2
-        version: 0.2.2(vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3))
+        version: 0.2.2(vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.7.2))(vue@3.5.13(typescript@5.7.2))
       vue-use-spring:
         specifier: ^0.3.3
-        version: 0.3.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+        version: 0.3.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
 
   packages/nuxt:
     dependencies:
@@ -167,8 +167,8 @@ importers:
   packages/online-playground:
     dependencies:
       '@vue/repl':
-        specifier: ^3.0.0
-        version: 3.4.0
+        specifier: ^4.4.2
+        version: 4.4.2
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -180,14 +180,17 @@ importers:
         version: link:../pinia
       vue:
         specifier: ^3.5.13
-        version: 3.5.13(typescript@5.6.3)
+        version: 3.5.13(typescript@5.7.2)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.2))
       execa:
         specifier: ^9.5.1
         version: 9.5.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.2
         version: 6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1)
@@ -218,7 +221,7 @@ importers:
     dependencies:
       '@vueuse/core':
         specifier: ^12.0.0
-        version: 12.0.0(typescript@5.6.3)
+        version: 12.0.0(typescript@5.7.2)
       mande:
         specifier: ^2.0.9
         version: 2.0.9
@@ -227,17 +230,17 @@ importers:
         version: link:../pinia
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4(vue@3.5.13(typescript@5.6.3))
+        version: 1.0.4(vue@3.5.13(typescript@5.7.2))
       vue-promised:
         specifier: ^2.2.0
-        version: 2.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+        version: 2.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
       vue-router:
         specifier: ^4.5.0
-        version: 4.5.0(vue@3.5.13(typescript@5.6.3))
+        version: 4.5.0(vue@3.5.13(typescript@5.7.2))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.2))
       vite:
         specifier: ^6.0.2
         version: 6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1)
@@ -259,14 +262,14 @@ importers:
     dependencies:
       vue-demi:
         specifier: ^0.14.10
-        version: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+        version: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     devDependencies:
       pinia:
         specifier: workspace:*
         version: link:../pinia
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.10.1))(jiti@2.4.0)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.10.1))(jiti@2.4.0)(postcss@8.4.49)(typescript@5.7.2)(yaml@2.6.1)
 
 packages:
 
@@ -1816,7 +1819,7 @@ packages:
   '@vue/language-core@2.1.10':
     resolution: {integrity: sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.6.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1824,8 +1827,8 @@ packages:
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
 
-  '@vue/repl@3.4.0':
-    resolution: {integrity: sha512-iHhIsmQsp9PJuOwverCRQC2owFb0FSFzk6YWwyirAX6AqH//2FrUV4WB16f9lGX5pDXAHjxlzAE6Lqf9P17HHA==}
+  '@vue/repl@4.4.2':
+    resolution: {integrity: sha512-MEAsBK/YzMFGINOBzqM40XTeIYAUsg7CqvXvD5zi0rhYEQrPfEUIdexmMjdm7kVKsKmcvIHxrFK2DFC35m9kHw==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
@@ -4886,6 +4889,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -5757,9 +5765,9 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@chenfengyuan/vue-countdown@2.1.2(vue@3.5.13(typescript@5.6.3))':
+  '@chenfengyuan/vue-countdown@2.1.2(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
@@ -6910,10 +6918,15 @@ snapshots:
       vite: 5.4.11(@types/node@22.10.1)(terser@5.36.0)
       vue: 3.5.13(typescript@5.6.3)
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.11(@types/node@22.10.1)(terser@5.36.0))(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      vite: 5.4.11(@types/node@22.10.1)(terser@5.36.0)
+      vue: 3.5.13(typescript@5.7.2)
+
+  '@vitejs/plugin-vue@5.2.1(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       vite: 6.0.2(@types/node@22.10.1)(jiti@2.4.0)(terser@5.36.0)(yaml@2.6.1)
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@vitest/coverage-v8@2.1.8(vitest@2.1.8)':
     dependencies:
@@ -7079,6 +7092,11 @@ snapshots:
       vue: 3.5.13(typescript@5.6.3)
     optional: true
 
+  '@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      vue: 3.5.13(typescript@5.7.2)
+    optional: true
+
   '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@7.6.4':
@@ -7128,7 +7146,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.13
 
-  '@vue/repl@3.4.0': {}
+  '@vue/repl@4.4.2': {}
 
   '@vue/runtime-core@3.5.13':
     dependencies:
@@ -7148,6 +7166,12 @@ snapshots:
       '@vue/shared': 3.5.13
       vue: 3.5.13(typescript@5.6.3)
 
+  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      vue: 3.5.13(typescript@5.7.2)
+
   '@vue/shared@3.5.13': {}
 
   '@vue/test-utils@2.4.6':
@@ -7155,40 +7179,40 @@ snapshots:
       js-beautify: 1.15.1
       vue-component-type-helpers: 2.0.22
 
-  '@vueuse/core@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))':
+  '@vueuse/core@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.2.0
-      '@vueuse/shared': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/shared': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))':
+  '@vueuse/core@11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.3.0
-      '@vueuse/shared': 11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/shared': 11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@12.0.0(typescript@5.6.3)':
+  '@vueuse/core@12.0.0(typescript@5.7.2)':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 12.0.0
-      '@vueuse/shared': 12.0.0(typescript@5.6.3)
-      vue: 3.5.13(typescript@5.6.3)
+      '@vueuse/shared': 12.0.0(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(focus-trap@7.6.2)(vue@3.5.13(typescript@5.6.3))':
+  '@vueuse/integrations@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(focus-trap@7.6.2)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      '@vueuse/core': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
-      '@vueuse/shared': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/core': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      '@vueuse/shared': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     optionalDependencies:
       change-case: 5.4.4
       focus-trap: 7.6.2
@@ -7202,23 +7226,23 @@ snapshots:
 
   '@vueuse/metadata@12.0.0': {}
 
-  '@vueuse/shared@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))':
+  '@vueuse/shared@11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))':
+  '@vueuse/shared@11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@12.0.0(typescript@5.6.3)':
+  '@vueuse/shared@12.0.0(typescript@5.7.2)':
     dependencies:
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - typescript
 
@@ -10264,9 +10288,9 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swrv@1.0.4(vue@3.5.13(typescript@5.6.3)):
+  swrv@1.0.4(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
   system-architecture@0.1.0: {}
 
@@ -10377,7 +10401,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.10.1))(jiti@2.4.0)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1):
+  tsup@8.3.5(@microsoft/api-extractor@7.48.0(@types/node@22.10.1))(jiti@2.4.0)(postcss@8.4.49)(typescript@5.7.2)(yaml@2.6.1):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.0)
       cac: 6.7.14
@@ -10398,7 +10422,7 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.1)
       postcss: 8.4.49
-      typescript: 5.6.3
+      typescript: 5.7.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -10421,13 +10445,13 @@ snapshots:
     dependencies:
       typedoc: 0.26.11(typescript@5.6.3)
 
-  typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.6.3)):
+  typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.7.2)):
     dependencies:
-      typedoc: 0.26.11(typescript@5.6.3)
+      typedoc: 0.26.11(typescript@5.7.2)
 
-  typedoc-vitepress-theme@1.1.1(typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.6.3))):
+  typedoc-vitepress-theme@1.1.1(typedoc-plugin-markdown@4.3.1(typedoc@0.26.11(typescript@5.7.2))):
     dependencies:
-      typedoc-plugin-markdown: 4.3.1(typedoc@0.26.11(typescript@5.6.3))
+      typedoc-plugin-markdown: 4.3.1(typedoc@0.26.11(typescript@5.7.2))
 
   typedoc@0.26.11(typescript@5.6.3):
     dependencies:
@@ -10438,9 +10462,20 @@ snapshots:
       typescript: 5.6.3
       yaml: 2.6.1
 
+  typedoc@0.26.11(typescript@5.7.2):
+    dependencies:
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      shiki: 1.23.1
+      typescript: 5.7.2
+      yaml: 2.6.1
+
   typescript@5.4.2: {}
 
   typescript@5.6.3: {}
+
+  typescript@5.7.2: {}
 
   uc.micro@2.1.0: {}
 
@@ -10761,16 +10796,16 @@ snapshots:
       terser: 5.36.0
       yaml: 2.6.1
 
-  vitepress-translation-helper@0.2.2(vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3)):
+  vitepress-translation-helper@0.2.2(vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.7.2))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       minimist: 1.2.8
       simple-git: 3.27.0
-      vitepress: 1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3)
-      vue: 3.5.13(typescript@5.6.3)
+      vitepress: 1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.6.3):
+  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@22.10.1)(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(postcss@8.4.49)(search-insights@2.17.2)(terser@5.36.0)(typescript@5.7.2):
     dependencies:
       '@docsearch/css': 3.8.0
       '@docsearch/js': 3.8.0(@algolia/client-search@5.15.0)(search-insights@2.17.2)
@@ -10779,17 +10814,17 @@ snapshots:
       '@shikijs/transformers': 1.23.1
       '@shikijs/types': 1.23.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.11(@types/node@22.10.1)(terser@5.36.0))(vue@3.5.13(typescript@5.6.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.11(@types/node@22.10.1)(terser@5.36.0))(vue@3.5.13(typescript@5.7.2))
       '@vue/devtools-api': 7.6.4
       '@vue/shared': 3.5.13
-      '@vueuse/core': 11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
-      '@vueuse/integrations': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(change-case@5.4.4)(focus-trap@7.6.2)(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/core': 11.3.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      '@vueuse/integrations': 11.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(change-case@5.4.4)(focus-trap@7.6.2)(vue@3.5.13(typescript@5.7.2))
       focus-trap: 7.6.2
       mark.js: 8.11.1
       minisearch: 7.1.0
       shiki: 1.23.1
       vite: 5.4.11(@types/node@22.10.1)(terser@5.36.0)
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
     optionalDependencies:
       postcss: 8.4.49
     transitivePeerDependencies:
@@ -10915,19 +10950,30 @@ snapshots:
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.6.3))
 
+  vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2)):
+    dependencies:
+      vue: 3.5.13(typescript@5.7.2)
+    optionalDependencies:
+      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.7.2))
+
   vue-devtools-stub@0.1.0: {}
 
-  vue-promised@2.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3)):
+  vue-promised@2.2.0(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      vue: 3.5.13(typescript@5.6.3)
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      vue: 3.5.13(typescript@5.7.2)
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.6.3))
+      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.7.2))
 
   vue-router@4.5.0(vue@3.5.13(typescript@5.6.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.13(typescript@5.6.3)
+
+  vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.7.2)
 
   vue-tsc@2.1.10(typescript@5.6.3):
     dependencies:
@@ -10936,12 +10982,12 @@ snapshots:
       semver: 7.6.3
       typescript: 5.6.3
 
-  vue-use-spring@0.3.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3)):
+  vue-use-spring@0.3.3(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      vue: 3.5.13(typescript@5.6.3)
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      vue: 3.5.13(typescript@5.7.2)
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
     optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.6.3))
+      '@vue/composition-api': 1.7.2(vue@3.5.13(typescript@5.7.2))
 
   vue@3.5.13(typescript@5.6.3):
     dependencies:
@@ -10952,6 +10998,16 @@ snapshots:
       '@vue/shared': 3.5.13
     optionalDependencies:
       typescript: 5.6.3
+
+  vue@3.5.13(typescript@5.7.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-sfc': 3.5.13
+      '@vue/runtime-dom': 3.5.13
+      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.7.2))
+      '@vue/shared': 3.5.13
+    optionalDependencies:
+      typescript: 5.7.2
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
Updates the Pinia Online Playground

- Fetches and utilizes the latest version of Vue
- Fetches and utilizes the latest version of TypeScript
- Updates the to the latest version of `@vue/repl` (I'm not super-familiar, so check my updates here)
- Updates the README and associated package commands

I was going to update the `tsconfig.json` to utilize `"strict": true` but didn't dig in to where this is sourced.