### PR TITLE
fix: shouldHydrate error when null object is passed

### DIFF
--- a/packages/nuxt/playground/pages/null-object-store.vue
+++ b/packages/nuxt/playground/pages/null-object-store.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+const store = useWithNullObjectStore()
+</script>
+
+<template>
+  <h2>null object</h2>
+  <p>{{ store.foo }}</p>
+</template>

--- a/packages/nuxt/playground/stores/with-null-οbject.ts
+++ b/packages/nuxt/playground/stores/with-null-οbject.ts
@@ -1,0 +1,12 @@
+export const useWithNullObjectStore = defineStore('with-null-object', () => {
+  return {
+    text: ref(Object.create(null)),
+    foo: ref('bar'),
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useWithNullObjectStore, import.meta.hot)
+  )
+}

--- a/packages/nuxt/test/nuxt.spec.ts
+++ b/packages/nuxt/test/nuxt.spec.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import { setup, $fetch } from '@nuxt/test-utils/e2e'
+import exp from 'node:constants'
 
 describe('works with nuxt', async () => {
   await setup({
@@ -26,6 +27,14 @@ describe('works with nuxt', async () => {
   it('works on ssr', async () => {
     const html = await $fetch('/')
     expect(html).toContain('Count: 101')
+  })
+
+  it('works with null objects', async () => {
+    expect(async () => {
+      const html = await $fetch('/null-object-store')
+      expect(html).toContain('null object')
+      expect(html).toContain('bar')
+    }).not.toThrow()
   })
 
   it('drops state that is marked with skipHydrate', async () => {

--- a/packages/pinia/__tests__/ssr.spec.ts
+++ b/packages/pinia/__tests__/ssr.spec.ts
@@ -152,6 +152,13 @@ describe('SSR', () => {
     expect(store.$state).toEqual({ start: 'start' })
   })
 
+  it('accepts a store with no null state', () => {
+    const pinia = createPinia()
+    pinia.state.value.a = Object.create(null)
+    const store = defineStore('a', {})(pinia)
+    expect(store.$state).toEqual({})
+  })
+
   describe('Setup Store', () => {
     const useStore = defineStore('main', () => {
       const count = ref(0)

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -136,7 +136,10 @@ export function skipHydrate<T = any>(obj: T): T {
  * @returns true if `obj` should be hydrated
  */
 export function shouldHydrate(obj: any) {
-  return !isPlainObject(obj) || !obj.hasOwnProperty(skipHydrateSymbol)
+  return (
+    !isPlainObject(obj) ||
+    !Object.prototype.hasOwnProperty.call(obj, skipHydrateSymbol)
+  )
 }
 
 const { assign } = Object


### PR DESCRIPTION
This fixes the error `Uncaught TypeError: *.hasOwnProperty is not a function` when passing a `null` Object

Fixes https://github.com/vuejs/pinia/issues/2837