### PR TITLE
docs: remove duplicate entries in changelog

### DIFF
--- a/packages/pinia/CHANGELOG.md
+++ b/packages/pinia/CHANGELOG.md
@@ -10,7 +10,7 @@ This version requires at least Vue 2.7. On January 2025, Pinia 3.0 will drop sup
 
 - avoid npm bug when resolving optional deps ([#2841](https://github.com/vuejs/pinia/issues/2841)) ([1e45f33](https://github.com/vuejs/pinia/commit/1e45f332efe8c0f543cfd186cd26b768abdf2b62))
 
-### [2.2.8](https://github.com/vuejs/pinia/compare/pinia@2.2.6...pinia@2.2.8) (2024-11-28)
+### [2.2.8](https://github.com/vuejs/pinia/compare/v2.2.7...v2.2.8) (2024-11-28)
 
 ### Features
 
@@ -21,7 +21,7 @@ This version requires at least Vue 2.7. On January 2025, Pinia 3.0 will drop sup
 - avoid immediate computing with `storeToRefs` ([67d3109](https://github.com/vuejs/pinia/commit/67d31094784cc3bd256b0636b79dc8e421f6c3fb)), closes [#2812](https://github.com/vuejs/pinia/issues/2812)
 - **types:** unwrap refs in `mapWritableState` for setup stores ([#2805](https://github.com/vuejs/pinia/issues/2805)) ([ea14e53](https://github.com/vuejs/pinia/commit/ea14e53fdfc0d0f4cd80d5242572f87714a77e3b)), closes [#2804](https://github.com/vuejs/pinia/issues/2804)
 
-### [2.2.7](https://github.com/vuejs/pinia/compare/pinia@2.2.6...pinia@2.2.7) (2024-11-27)
+### [2.2.7](https://github.com/vuejs/pinia/compare/pinia@2.2.6...v2.2.7) (2024-11-27)
 
 ### Bug Fixes
 

--- a/packages/pinia/CHANGELOG.md
+++ b/packages/pinia/CHANGELOG.md
@@ -10,23 +10,6 @@ This version requires at least Vue 2.7. On January 2025, Pinia 3.0 will drop sup
 
 - avoid npm bug when resolving optional deps ([#2841](https://github.com/vuejs/pinia/issues/2841)) ([1e45f33](https://github.com/vuejs/pinia/commit/1e45f332efe8c0f543cfd186cd26b768abdf2b62))
 
-### 2.2.8 (2024-11-28)
-
-### Features
-
-- deprecate old defineStore ([d1858e8](https://github.com/vuejs/pinia/commit/d1858e8c932d89cd2bf9121fe62179795ebb5c5f))
-
-### Bug Fixes
-
-- avoid immediate computing with `storeToRefs` ([67d3109](https://github.com/vuejs/pinia/commit/67d31094784cc3bd256b0636b79dc8e421f6c3fb)), closes [#2812](https://github.com/vuejs/pinia/issues/2812)
-- **types:** unwrap refs in `mapWritableState` for setup stores ([#2805](https://github.com/vuejs/pinia/issues/2805)) ([ea14e53](https://github.com/vuejs/pinia/commit/ea14e53fdfc0d0f4cd80d5242572f87714a77e3b)), closes [#2804](https://github.com/vuejs/pinia/issues/2804)
-
-### 2.2.7 (2024-11-27)
-
-### Bug Fixes
-
-- **devtools:** avoid running outside of browsers ([eb5e6fd](https://github.com/vuejs/pinia/commit/eb5e6fd6073da8e828a9087c876d0e8fde3cdb3d)), closes [#2843](https://github.com/vuejs/pinia/issues/2843)
-
 ### [2.2.8](https://github.com/vuejs/pinia/compare/pinia@2.2.6...pinia@2.2.8) (2024-11-28)
 
 ### Features


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

I just noticed there were some duplicated entries in the CHANGELOG, so I'm suggesting a simple fix here 🙇 

NB: I also noticed afterwards that the links/tags used for the version header were incorrect, so I'm also including a small fix for those, but I'm not sure if those changes are intended. Please let me know if this should be done differently or separately.