### PR TITLE
docs: minor corrections

### DIFF
--- a/packages/docs/cookbook/composables.md
+++ b/packages/docs/cookbook/composables.md
@@ -40,7 +40,7 @@ Here are some examples of composables that cannot be used in an option stores (b
 On the other hand, when defining a setup store, you can use almost any composable since every property gets discerned into state, action, or getter:
 
 ```ts
-import { defineStore, skipHydrate } from 'pinia'
+import { defineStore } from 'pinia'
 import { useMediaControls } from '@vueuse/core'
 
 export const useVideoPlayer = defineStore('video', () => {
@@ -78,7 +78,7 @@ When dealing with [Server Side Rendering](../ssr/index.md), you need to take car
 In [Option Stores](#option-stores), you need to define a `hydrate()` function. This function is called when the store is instantiated on the client (the browser) when there is an initial state available at the time the store is created. The reason we need to define this function is because in such scenario, `state()` is not called.
 
 ```ts
-import { defineStore, skipHydrate } from 'pinia'
+import { defineStore } from 'pinia'
 import { useLocalStorage } from '@vueuse/core'
 
 export const useAuthStore = defineStore('auth', {

--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -47,7 +47,9 @@ Note that if one store uses another store, you can directly import and call the 
 When it comes to _setup stores_, you can simply use one of the stores **at the top** of the store function:
 
 ```ts
+import { defineStore } from 'pinia'
 import { useUserStore } from './user'
+import { apiPurchase } from './api'
 
 export const useCartStore = defineStore('cart', () => {
   const user = useUserStore()
@@ -58,7 +60,7 @@ export const useCartStore = defineStore('cart', () => {
   })
 
   function purchase() {
-    return apiPurchase(user.id, this.list)
+    return apiPurchase(user.id, list.value)
   }
 
   return { summary, purchase }
@@ -91,7 +93,8 @@ The same applies to _actions_:
 ```js
 import { defineStore } from 'pinia'
 import { useUserStore } from './user'
-
+import { apiOrderCart } from './api'
+ 
 export const useCartStore = defineStore('cart', {
   actions: {
     async orderCart() {
@@ -114,7 +117,8 @@ Since actions can be asynchronous, make sure **all of your `useStore()` calls ap
 ```js{7-8,11-13}
 import { defineStore } from 'pinia'
 import { useUserStore } from './user'
-
+import { apiOrderCart } from './api'
+  
 export const useCartStore = defineStore('cart', {
   actions: {
     async orderCart() {

--- a/packages/docs/cookbook/vscode-snippets.md
+++ b/packages/docs/cookbook/vscode-snippets.md
@@ -2,7 +2,7 @@
 
 These are some snippets that I use in VS Code to make my life easier.
 
-Manage user snippets with <kbd>⇧</kbd> <kbd>⌘</kbd> <kbd>P</kbd> / <kbd>⇧</kbd> <kbd>⌃</kbd> <kbd>P</kbd> and then `Snippets: Configure User Snippets`.
+Manage user snippets with <kbd>⇧ Shift</kbd>+<kbd>⌘ Command</kbd>+<kbd>P</kbd> / <kbd>⇧ Shift</kbd>+<kbd>⌃ Control</kbd>+<kbd>P</kbd> and then `Snippets: Configure User Snippets`.
 
 ```json
 {


### PR DESCRIPTION
The list of changes:

- Replaced obscure key symbols with their full, explicit key names for better readability
- Removed the unused `skipHydrate` import from certain code snippets
- Fixed an issue where the ref value was not read correctly by replacing `this.list` with `list.value`