### PR TITLE
ci: indent and branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'packages/docs/**'
       - 'packages/playground/**'
   pull_request:
-    branches: v2
+    branches: [v2]
     paths-ignore:
       - 'packages/docs/**'
       - 'packages/playground/**'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -2,40 +2,40 @@ name: Publish Any Commit
 
 on:
   pull_request:
-    branches: v2
+    branches: [v2]
     paths-ignore:
-    - 'packages/docs/**'
-    - 'packages/playground/**'
+      - 'packages/docs/**'
+      - 'packages/playground/**'
 
   push:
     branches:
-    - '**'
+      - '**'
     tags:
-    - '!**'
+      - '!**'
     paths-ignore:
-    - 'packages/docs/**'
-    - 'packages/playground/**'
+      - 'packages/docs/**'
+      - 'packages/playground/**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-        cache: pnpm
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
 
-    - name: Install
-      run: pnpm install --frozen-lockfile
+      - name: Install
+        run: pnpm install --frozen-lockfile
 
-    - name: Build
-      run: pnpm build
+      - name: Build
+        run: pnpm build
 
-    - name: Release
-      run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*'
+      - name: Release
+        run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*'

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -120,6 +120,6 @@ export function storeToRefs<SS extends StoreGeneric>(
       }
     }
 
-    return refs
+    return { ...store.actions, ...refs }
   }
 }

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -120,6 +120,6 @@ export function storeToRefs<SS extends StoreGeneric>(
       }
     }
 
-    return { ...store.actions, ...refs }
+    return refs
   }
 }


### PR DESCRIPTION
#### Discussion

https://github.com/vuejs/pinia/discussions/2506

#### Description
- [x] Return actions in the `storeToRefs` method
- [x] Fixes branches declaration for github actions workflows

This pull request includes several changes to configuration and code files, focusing on workflow updates and a modification to the `storeToRefs` function in the `pinia` package.

Workflow configuration updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL9-R9): Updated the `pull_request` branches configuration to use an array format.
* [`.github/workflows/pkg.pr.new.yml`](diffhunk://#diff-9d547244c7ba3708e5e91d967e697a2aa540f2421ec5568dbb7915fd868d155fL5-R5): Updated the `pull_request` branches configuration to use an array format.

Code modification:

* [`packages/pinia/src/storeToRefs.ts`](diffhunk://#diff-a4019455d4214f4ae04e5e463a0b67af62b68c0267b436ab16beeaaf45bc32d3L123-R123): Modified the `storeToRefs` function to return an object that includes both `store.actions` and `refs`.
