### PR TITLE
test: deprecated syntax

### DIFF
--- a/packages/pinia/__tests__/actions.spec.ts
+++ b/packages/pinia/__tests__/actions.spec.ts
@@ -5,8 +5,7 @@ describe('Actions', () => {
   const useStore = () => {
     // create a new store
     setActivePinia(createPinia())
-    return defineStore({
-      id: 'main',
+    return defineStore('main', {
       state: () => ({
         a: true,
         nested: {
@@ -55,13 +54,11 @@ describe('Actions', () => {
     })()
   }
 
-  const useB = defineStore({
-    id: 'B',
+  const useB = defineStore('B', {
     state: () => ({ b: 'b' }),
   })
 
-  const useA = defineStore({
-    id: 'A',
+  const useA = defineStore('A', {
     state: () => ({ a: 'a' }),
     actions: {
       swap() {

--- a/packages/pinia/__tests__/getters.spec.ts
+++ b/packages/pinia/__tests__/getters.spec.ts
@@ -9,8 +9,7 @@ describe('Getters', () => {
     setActivePinia(createPinia())
   })
 
-  const useStore = defineStore({
-    id: 'main',
+  const useStore = defineStore('main', {
     state: () => ({
       name: 'Eduardo',
     }),
@@ -40,13 +39,11 @@ describe('Getters', () => {
     },
   })
 
-  const useB = defineStore({
-    id: 'B',
+  const useB = defineStore('B', {
     state: () => ({ b: 'b' }),
   })
 
-  const useA = defineStore({
-    id: 'A',
+  const useA = defineStore('A', {
     state: () => ({ a: 'a' }),
     getters: {
       fromB(): string {

--- a/packages/pinia/__tests__/lifespan.spec.ts
+++ b/packages/pinia/__tests__/lifespan.spec.ts
@@ -19,8 +19,7 @@ import {
 
 describe('Store Lifespan', () => {
   function defineMyStore() {
-    return defineStore({
-      id: 'main',
+    return defineStore('main', {
       state: () => ({
         a: true,
         n: 0,
@@ -118,8 +117,7 @@ describe('Store Lifespan', () => {
     const globalWatch = vi.fn()
     const destroy = watch(() => pinia.state.value.a?.n, globalWatch)
 
-    const useStore = defineStore({
-      id: 'a',
+    const useStore = defineStore('a', {
       state: () => {
         n = n || ref(0)
         return { n }

--- a/packages/pinia/__tests__/mapHelpers.spec.ts
+++ b/packages/pinia/__tests__/mapHelpers.spec.ts
@@ -14,8 +14,7 @@ import { nextTick, defineComponent, ref, computed } from 'vue'
 import { mockWarn } from './vitest-mock-warn'
 
 describe('Map Helpers', () => {
-  const useStore = defineStore({
-    id: 'main',
+  const useStore = defineStore('main', {
     state: () => ({
       a: true,
       n: 0,
@@ -147,8 +146,7 @@ describe('Map Helpers', () => {
   })
 
   describe('mapActions', () => {
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({ n: 0 }),
       actions: {
         increment() {

--- a/packages/pinia/__tests__/onAction.spec.ts
+++ b/packages/pinia/__tests__/onAction.spec.ts
@@ -7,8 +7,7 @@ describe('Subscriptions', () => {
   const useStore = () => {
     // create a new store
     setActivePinia(createPinia())
-    return defineStore({
-      id: 'main',
+    return defineStore('main', {
       state: () => ({
         user: 'Eduardo',
       }),
@@ -168,8 +167,7 @@ describe('Subscriptions', () => {
   })
 
   describe('multiple store instances', () => {
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({
         name: 'Eduardo',
       }),

--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -151,8 +151,7 @@ describe('State', () => {
 
     const pinia = createPinia()
     setActivePinia(pinia)
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({
         name,
         counter,

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -6,8 +6,7 @@ describe('store.$patch', () => {
   const useStore = () => {
     // create a new store
     setActivePinia(createPinia())
-    return defineStore({
-      id: 'main',
+    return defineStore('main', {
       state: () => ({
         a: true,
         nested: {
@@ -22,8 +21,7 @@ describe('store.$patch', () => {
   const useArrayStore = () => {
     // create a new store
     setActivePinia(createPinia())
-    return defineStore({
-      id: 'main',
+    return defineStore('main', {
       state: () => ({
         items: [{ id: 0 }],
         currentItem: { id: 1 },
@@ -141,8 +139,7 @@ describe('store.$patch', () => {
     const useStore = (pinia?: Pinia) => {
       // create a new store
       setActivePinia(pinia || createPinia())
-      return defineStore({
-        id: 'main',
+      return defineStore('main', {
         state: () => ({
           arr: [] as any[],
           name: 'Eduardo',

--- a/packages/pinia/__tests__/store.spec.ts
+++ b/packages/pinia/__tests__/store.spec.ts
@@ -11,8 +11,7 @@ describe('Store', () => {
     setActivePinia(createPinia())
   })
 
-  const useStore = defineStore({
-    id: 'main',
+  const useStore = defineStore('main', {
     state: () => ({
       a: true,
       nested: {
@@ -23,7 +22,7 @@ describe('Store', () => {
   })
 
   it('reuses a store', () => {
-    const useStore = defineStore({ id: 'main' })
+    const useStore = defineStore('main', {})
     expect(useStore()).toBe(useStore())
   })
 
@@ -56,8 +55,7 @@ describe('Store', () => {
   it('works without setting the active pinia', async () => {
     setActivePinia(undefined)
     const pinia = createPinia()
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({ n: 0 }),
     })
     const TestComponent = defineComponent({
@@ -100,7 +98,7 @@ describe('Store', () => {
   })
 
   it('can create an empty state if no state option is provided', () => {
-    const store = defineStore({ id: 'some' })()
+    const store = defineStore('some', {})()
 
     expect(store.$state).toEqual({})
   })
@@ -108,8 +106,7 @@ describe('Store', () => {
   it('can hydrate the state', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({
         a: true,
         nested: {
@@ -177,8 +174,7 @@ describe('Store', () => {
 
   it('should outlive components', async () => {
     const pinia = createPinia()
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({ n: 0 }),
     })
 
@@ -250,7 +246,7 @@ describe('Store', () => {
 
   it('reuses stores from parent components', () => {
     let s1, s2
-    const useStore = defineStore({ id: 'one' })
+    const useStore = defineStore('one', {})
     const pinia = createPinia()
 
     const Child = defineComponent({
@@ -277,7 +273,7 @@ describe('Store', () => {
   })
 
   it('can share the same pinia in two completely different instances', async () => {
-    const useStore = defineStore({ id: 'one', state: () => ({ n: 0 }) })
+    const useStore = defineStore('one', { state: () => ({ n: 0 }) })
     const pinia = createPinia()
 
     const Comp = defineComponent({
@@ -314,8 +310,7 @@ describe('Store', () => {
 
   it('can be disposed', () => {
     const pinia = createPinia()
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({ n: 0 }),
     })
 
@@ -341,8 +336,7 @@ describe('Store', () => {
   it('warns when state is created with a class constructor', () => {
     class MyState {}
 
-    const useMyStore = defineStore({
-      id: 'store',
+    const useMyStore = defineStore('store', {
       state: () => new MyState(),
     })
     useMyStore()
@@ -351,8 +345,7 @@ describe('Store', () => {
 
   it('only warns about constructors when store is initially created', () => {
     class MyState {}
-    const useMyStore = defineStore({
-      id: 'arrowInit',
+    const useMyStore = defineStore('arrowInit', {
       state: () => new MyState(),
     })
     useMyStore()
@@ -360,8 +353,7 @@ describe('Store', () => {
   })
 
   it('does not warn when state is created with a plain object', () => {
-    const useMyStore = defineStore({
-      id: 'poInit',
+    const useMyStore = defineStore('poInit', {
       state: () => ({ someValue: undefined }),
     })
     useMyStore()

--- a/packages/pinia/__tests__/storePlugins.spec.ts
+++ b/packages/pinia/__tests__/storePlugins.spec.ts
@@ -194,7 +194,6 @@ describe('store plugins', () => {
 
   it('passes the options of the options store', async () => {
     const options = {
-      id: 'main',
       state: () => ({ n: 0 }),
       actions: {
         increment() {
@@ -208,7 +207,7 @@ describe('store plugins', () => {
         },
       },
     }
-    const useStore = defineStore(options)
+    const useStore = defineStore('main', options)
     const pinia = createPinia()
     mount({ template: 'none' }, { global: { plugins: [pinia] } })
 

--- a/packages/pinia/__tests__/storeSetup.spec.ts
+++ b/packages/pinia/__tests__/storeSetup.spec.ts
@@ -102,8 +102,7 @@ describe('store with setup syntax', () => {
 
     const pinia = createPinia()
     setActivePinia(pinia)
-    const useStore = defineStore({
-      id: 'main',
+    const useStore = defineStore('main', {
       state: () => ({
         name,
         counter,

--- a/packages/pinia/test-dts/actions.test-d.ts
+++ b/packages/pinia/test-dts/actions.test-d.ts
@@ -1,7 +1,6 @@
 import { defineStore, expectType } from './'
 
-const useStore = defineStore({
-  id: 'name',
+const useStore = defineStore('name', {
   state: () => ({ count: 0 }),
   actions: {
     useOtherAction() {

--- a/packages/pinia/test-dts/customizations.test-d.ts
+++ b/packages/pinia/test-dts/customizations.test-d.ts
@@ -57,8 +57,7 @@ pinia.use((context) => {
   }
 })
 
-const useStore = defineStore({
-  id: 'main',
+const useStore = defineStore('main', {
   actions: {
     one() {},
     two() {

--- a/packages/pinia/test-dts/mapHelpers.test-d.ts
+++ b/packages/pinia/test-dts/mapHelpers.test-d.ts
@@ -9,8 +9,7 @@ import {
 import { describe, it, expectTypeOf } from 'vitest'
 
 describe('mapHelpers', () => {
-  const useOptionsStore = defineStore({
-    id: 'name',
+  const useOptionsStore = defineStore('name', {
     state: () => ({ a: 'on' as 'on' | 'off', nested: { counter: 0 } }),
     getters: {
       upper: (state) => state.a.toUpperCase(),
@@ -42,13 +41,11 @@ describe('mapHelpers', () => {
     return { a, upper, writableUpper, toggleA, setToggle }
   })
 
-  const useCounter = defineStore({
-    id: 'counter',
+  const useCounter = defineStore('counter', {
     state: () => ({ n: 0 }),
   })
 
-  const useStoreDos = defineStore({
-    id: 'dos',
+  const useStoreDos = defineStore('dos', {
     state: () => ({}),
   })
 

--- a/packages/pinia/test-dts/onAction.test-d.ts
+++ b/packages/pinia/test-dts/onAction.test-d.ts
@@ -1,7 +1,6 @@
 import { defineStore, expectType } from './'
 
-const useStore = defineStore({
-  id: 'main',
+const useStore = defineStore('main', {
   state: () => ({
     user: 'Eduardo',
   }),

--- a/packages/pinia/test-dts/store.test-d.ts
+++ b/packages/pinia/test-dts/store.test-d.ts
@@ -7,8 +7,7 @@ import {
 } from './'
 import { computed, Ref, ref, UnwrapRef, watch, WritableComputedRef } from 'vue'
 
-const useStore = defineStore({
-  id: 'name',
+const useStore = defineStore('name', {
   state: () => ({ a: 'on' as 'on' | 'off', nested: { counter: 0 } }),
   getters: {
     upper: (state) => {
@@ -54,8 +53,7 @@ defineStore('name', {
 })
 
 // actions on not existing properties
-defineStore({
-  id: '',
+defineStore('', {
   actions: {
     a() {
       // @ts-expect-error
@@ -64,8 +62,7 @@ defineStore({
   },
 })
 
-defineStore({
-  id: '',
+defineStore('', {
   state: () => ({}),
   actions: {
     a() {
@@ -75,8 +72,7 @@ defineStore({
   },
 })
 
-defineStore({
-  id: '',
+defineStore('', {
   getters: {},
   actions: {
     a() {
@@ -113,8 +109,7 @@ const s = init()()
 s.set({ id: 1 })
 
 // getters on not existing properties
-defineStore({
-  id: '',
+defineStore('', {
   getters: {
     a(): number {
       // @ts-expect-error
@@ -129,8 +124,7 @@ defineStore({
   },
 })
 
-defineStore({
-  id: '',
+defineStore('', {
   state: () => ({}),
   getters: {
     a(): number {
@@ -174,33 +168,25 @@ store.$patch(() => {
   return
 })
 
-const useNoSAG = defineStore({
-  id: 'noSAG',
-})
-const useNoAG = defineStore({
-  id: 'noAG',
+const useNoSAG = defineStore('noSAG', {})
+const useNoAG = defineStore('noAG', {
   state: () => ({}),
 })
-const useNoSG = defineStore({
-  id: 'noAG',
+const useNoSG = defineStore('noAG', {
   actions: {},
 })
-const useNoSA = defineStore({
-  id: 'noAG',
+const useNoSA = defineStore('noAG', {
   getters: {},
 })
-const useNoS = defineStore({
-  id: 'noAG',
+const useNoS = defineStore('noAG', {
   actions: {},
   getters: {},
 })
-const useNoA = defineStore({
-  id: 'noAG',
+const useNoA = defineStore('noAG', {
   state: () => ({}),
   getters: {},
 })
-const useNoG = defineStore({
-  id: 'noAG',
+const useNoG = defineStore('noAG', {
   state: () => ({}),
   actions: {},
 })

--- a/packages/playground/src/stores/cart.ts
+++ b/packages/playground/src/stores/cart.ts
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
 import { useUserStore } from './user'
 
-export const useCartStore = defineStore({
-  id: 'cart',
+export const useCartStore = defineStore('cart', {
   state: () => ({
     rawItems: [] as string[],
   }),

--- a/packages/playground/src/stores/jokesUsePromised.ts
+++ b/packages/playground/src/stores/jokesUsePromised.ts
@@ -3,9 +3,7 @@ import { getRandomJoke, Joke } from '../api/jokes'
 import { usePromise } from 'vue-promised'
 import { ref, watch } from 'vue'
 
-export const useJokes = defineStore({
-  id: 'jokes-vue-promised',
-
+export const useJokes = defineStore('jokes-vue-promised', {
   state: () => {
     const promise = ref(getRandomJoke())
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -29,7 +29,7 @@ function getAuthors(pkg) {
   const { contributors, author } = pkg
 
   const authors = new Set()
-  if (contributors && contributors)
+  if (contributors)
     contributors.forEach((contributor) => {
       authors.add(contributor.name)
     })


### PR DESCRIPTION
Updated tests to avoid using the [deprecated syntax](https://pinia.vuejs.org/api/pinia/functions/defineStore.html#defineStore-id-storeSetup-options-) of the `defineStore` function.