### PR TITLE
fix(nuxt): global pinia instance leads to whole nuxt context not being garbage collected

### DIFF
--- a/packages/nuxt/src/runtime/plugin.vue3.ts
+++ b/packages/nuxt/src/runtime/plugin.vue3.ts
@@ -1,7 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
-import { defineNuxtPlugin, type Plugin } from '#app'
-import { toRaw } from 'vue'
+import { defineNuxtPlugin, useNuxtApp, type Plugin } from '#app'
 
 const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin({
   name: 'pinia',
@@ -10,9 +9,7 @@ const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin({
     nuxtApp.vueApp.use(pinia)
     setActivePinia(pinia)
 
-    if (import.meta.server) {
-      nuxtApp.payload.pinia = toRaw(pinia.state.value)
-    } else if (nuxtApp.payload && nuxtApp.payload.pinia) {
+    if (nuxtApp.payload && nuxtApp.payload.pinia) {
       pinia.state.value = nuxtApp.payload.pinia as any
     }
 
@@ -22,6 +19,13 @@ const plugin: Plugin<{ pinia: Pinia }> = defineNuxtPlugin({
         pinia,
       },
     }
+  },
+  hooks: {
+    'app:rendered'() {
+      const nuxtApp = useNuxtApp()
+      nuxtApp.payload.pinia = (nuxtApp.$pinia as Pinia).state.value
+      setActivePinia(undefined)
+    },
   },
 })
 


### PR DESCRIPTION
I discovered this during testing of a memory leak in our nuxt application. We were providing our apollo client in a plugin as well and it would never be garbage collected.

Relatively simple to test. 
- setup a nuxt project with pinia (not even a store necessary). 
- build the project
- run it with
```sh
node --inspect --expose-gc  .output/server/index.mjs
```
- use e.g. chrome to take a node heap snapshot
- with pinia the third object there will appear -> without pinia i doesn't appear as it is garbace collected

Reason:
The reason behind it is, that calling setActivePinia(pinia) writes it in a global variable, which is not cleared after ssr is done -> the same reference is passed to the nuxt plugin provide return. Keeping the activePinia instance leads to the whole nuxt context not being garbage collected.

![grafik](https://github.com/user-attachments/assets/7b56b4f2-b894-4ff8-bb72-1120e5ffc352)
In the Screenshot you can see that the activePinia keeps everything alive even after ssr is done.

Sadly I have no idea how to write a test for that.

(This is my first open source contribution so i might have no idea what i am doing :D)
