### PR TITLE
fix(devtools): modernize MouseEvent initialization

### DIFF
--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -27,7 +27,7 @@ const theme: Theme = {
       'aside-ads-before': () => h(AsideSponsors),
       // 'layout-top': () => h(VuejsdeConfBanner),
       'doc-before': () => h(TranslationStatus, { status, i18nLabels }),
-      'layout-top': () => h(MadVueBanner)
+      'layout-top': () => h(MadVueBanner),
     })
   },
 

--- a/packages/pinia/src/devtools/file-saver.ts
+++ b/packages/pinia/src/devtools/file-saver.ts
@@ -68,24 +68,22 @@ function click(node: Element) {
   try {
     node.dispatchEvent(new MouseEvent('click'))
   } catch (e) {
-    const evt = document.createEvent('MouseEvents')
-    evt.initMouseEvent(
-      'click',
-      true,
-      true,
-      window,
-      0,
-      0,
-      0,
-      80,
-      20,
-      false,
-      false,
-      false,
-      false,
-      0,
-      null
-    )
+    const evt = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      detail: 0,
+      screenX: 80,
+      screenY: 20,
+      clientX: 80,
+      clientY: 20,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      metaKey: false,
+      button: 0,
+      relatedTarget: null,
+    })
     node.dispatchEvent(evt)
   }
 }


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

resolve #xxx

# Description

Replaced deprecated `initMouseEvent` method with modern `MouseEvent` constructor for better compatibility and future-proofing

The `initMouseEvent` method has been officially deprecated in favor of the more modern `MouseEvent` constructor. This change:


References:
- https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent
- https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent