### PR TITLE
docs: fix subscription arguments in docs

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -259,7 +259,7 @@ cartStore.$subscribe((mutation, state) => {
 Under the hood, `$subscribe()` uses Vue's `watch()` function. You can pass the same options as you would with `watch()`. This is useful when you want to immediately trigger subscriptions after **each** state change:
 
 ```ts{4}
-cartStore.$subscribe((state) => {
+cartStore.$subscribe((mutation, state) => {
   // persist the whole state to the local storage whenever it changes
   localStorage.setItem('cart', JSON.stringify(state))
 }, { flush: 'sync' })


### PR DESCRIPTION
Fixes a minor typo in subscription docs. The arguments should be `(mutation, state)`, not `(state)`.
