### PR TITLE
chore: split installation commands

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -28,7 +28,6 @@ bun add pinia
 
 :::
 
-
 :::tip
 If your app is using Vue <2.7, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).
 :::

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -9,7 +9,11 @@ Install `pinia` with your favorite package manager:
 
 ```bash
 yarn add pinia
-# or with npm
+```
+
+Or with npm
+
+```bash
 npm install pinia
 ```
 

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -18,6 +18,14 @@ npm install pinia
 yarn add pinia
 ```
 
+```bash [pnpm]
+pnpm add pinia
+```
+
+```bash [bun]
+bun add pinia
+```
+
 :::
 
 

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -7,15 +7,19 @@
 
 Install `pinia` with your favorite package manager:
 
-```bash
+
+::: code-group
+
+```bash [npm]
+npm install pinia
+```
+
+```bash [yarn]
 yarn add pinia
 ```
 
-Or with npm
+:::
 
-```bash
-npm install pinia
-```
 
 :::tip
 If your app is using Vue <2.7, you also need to install the composition api: `@vue/composition-api`. If you are using Nuxt, you should follow [these instructions](/ssr/nuxt.md).


### PR DESCRIPTION
Currently, the installation commands for `yarn` and `npm` are combined in a single codeblock. When users click the copy button, both commands are copied together, forcing them to manually edit the pasted text. This PR splits them into separate codeblocks, allowing users to copy only the command they need, making the process more UX friendly.