### PR TITLE
fix(docs): Props destructuring suggestion is not true anymore with the release of vue 3.5

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -136,7 +136,7 @@ import { computed } from 'vue'
 
 const store = useCounterStore()
 // ❌ This won't work because it breaks reactivity
-// it's the same as destructuring from `props`
+// it's the same as destructuring from `props` for Vue < 3.5
 const { name, doubleCount } = store // [!code warning]
 name // will always be "Eduardo" // [!code warning]
 doubleCount // will always be 0 // [!code warning]

--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -136,7 +136,7 @@ import { computed } from 'vue'
 
 const store = useCounterStore()
 // ❌ This won't work because it breaks reactivity
-// it's the same as destructuring from `props` for Vue < 3.5
+// same as reactive: https://vuejs.org/guide/essentials/reactivity-fundamentals.html#limitations-of-reactive
 const { name, doubleCount } = store // [!code warning]
 name // will always be "Eduardo" // [!code warning]
 doubleCount // will always be 0 // [!code warning]


### PR DESCRIPTION

Constrained the hint to vue < 3.5, because from 3.5 props destructuring is reactive