### PR TITLE
Fix: replace `data` with `state`

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -32,7 +32,7 @@ export const useStore = defineStore('storeId', {
 
 :::tip
 
-In order for Vue to properly detect state, you must declare every state piece in `data`, even if its initial value is `undefined`.
+In order for Vue to properly detect state, you must declare every state piece in `state`, even if its initial value is `undefined`.
 
 :::
 


### PR DESCRIPTION
Every piece in the object that returns `state` is what must be declared. Even though we can think of `state` *as* the `data` of the store, but I believe that it can be confussing to use both terms indistinctly.

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
