### PR TITLE
fix: can't access property "size", store._customProperties is undefined

### DIFF
--- a/packages/pinia/src/devtools/formatting.ts
+++ b/packages/pinia/src/devtools/formatting.ts
@@ -159,7 +159,7 @@ export function formatStoreForInspectorState(
     }))
   }
 
-  if (store._customProperties.size) {
+  if (store._customProperties && store._customProperties.size) {
     state.customProperties = Array.from(store._customProperties).map((key) => ({
       editable: true,
       key,


### PR DESCRIPTION
When using Pinia module in the Vue dev tools in Firefox (Zen browser) and I select a store the following error occurs, it is fixed by checking if `store._customProperties` exists.

<img width="742" height="322" alt="Screenshot 2025-07-15 at 13 48 36" src="https://github.com/user-attachments/assets/d7fb2f7a-3d4b-4a33-acd9-dc80c3e3bcc4" />

When I set a breakpoint and set `store._customProperties` to a new Map() it seems to work.

<img width="819" height="483" alt="Screenshot 2025-07-15 at 13 48 21" src="https://github.com/user-attachments/assets/ae2cd030-1ea7-4dcf-9181-e992644611a6" />
