### PR TITLE
fix(nuxt): mark compatibility for nuxt v4 stable

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -27,7 +27,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     name: 'pinia',
     configKey: 'pinia',
     compatibility: {
-      nuxt: '^3.15.0 || ^4.0.0-0 || ^4.0.0',
+      nuxt: '^3.15.0 || ^4.0.0',
     },
   },
   defaults: {},

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -27,7 +27,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     name: 'pinia',
     configKey: 'pinia',
     compatibility: {
-      nuxt: '^3.15.0 || ^4.0.0-0',
+      nuxt: '^3.15.0 || ^4.0.0-0 || ^4.0.0',
     },
   },
   defaults: {},


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
Resolves #3008 

Nuxt v4 (the non-alpha version) has a version that the current compatibility string doesn't capture. This adds the new stable version to the compatibility string (we may want to combine the 2 v4 strings)