### PR TITLE
Update Nuxt module README

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,6 +1,6 @@
 # `@pinia/nuxt`
 
-✨ Nuxt module for Pinia
+> Nuxt module for Pinia
 
 ## Automatic Installation
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,29 +1,56 @@
 # `@pinia/nuxt`
 
-> Nuxt 2 & 3 module
+✨ Nuxt module for Pinia
 
-## Installation
+## Automatic Installation
+
+Use `nuxi` to automatically add this module to your Nuxt project:
+
+```shell
+npx nuxi@latest module add pinia
+```
+
+## Manual Installation
+
+Add dependencies to your Nuxt project:
 
 ```shell
 npm i pinia @pinia/nuxt
 ```
 
-## Usage
-
-Add to `modules` (Nuxt 3) or `buildModules` (Nuxt 2) in `nuxt.config.js`:
+Enable the `@pinia/nuxt` module in `nuxt.config.ts`:
 
 ```js
-// Nuxt 2
-export default {
-  buildModules: [['@pinia/nuxt', { disableVuex: true }]],
-}
-// Nuxt 3
 export default defineNuxtConfig({
     modules: ['@pinia/nuxt'],
 })
 ```
 
-Note you also need `@nuxtjs/composition-api` if you are using Nuxt 2 without Bridge. [Refer to docs for more](https://pinia.vuejs.org/ssr/nuxt.html).
+## Configuring the Module
+
+By default, this module adds `stores` folder to auto imports, in which you can organize code related to Pinia stores in one place.
+> [!TIP]
+> In the new directory structure introduced since Nuxt 4, this directory is `app/stores`.
+
+You can customize this behaviour using the `pinia` property in `nuxt.config.ts`:
+
+```js
+export default defineNuxtConfig({
+    modules: ['@pinia/nuxt'],
+    // configure the module using `pinia` property
+    pinia: {
+      /**
+       * Automatically add stores dirs to the auto imports. This is the same as
+       * directly adding the dirs to the `imports.dirs` option. If you want to
+       * also import nested stores, you can use the glob pattern `./stores/**`
+       * (on Nuxt 3) or `app/stores/**` (on Nuxt 4+)
+       *
+       * @default `['stores']`
+       */
+        storesDirs: []
+    }
+})
+```
 
 ## License
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -16,6 +16,7 @@ export interface ModuleOptions {
    * Automatically add stores dirs to the auto imports. This is the same as
    * directly adding the dirs to the `imports.dirs` option. If you want to
    * also import nested stores, you can use the glob pattern `./stores/**`
+   * (on Nuxt 3) or `app/stores/**` (on Nuxt 4+)
    *
    * @default `['stores']`
    */


### PR DESCRIPTION
This PR rewrites README for `@pinia/nuxt`, which is also displayed at [module page](https://nuxt.com/modules/pinia). Specifically, the changes include:
- remove mention of Nuxt 2 and Nuxt Bridge
- add automatic installation guide
- describe module configuration and mention auto import
- add note for Nuxt 4's new directory structure