### PR TITLE
docs: Fix incorrect flush-timing description in zh docs

### DIFF
--- a/packages/docs/zh/core-concepts/state.md
+++ b/packages/docs/zh/core-concepts/state.md
@@ -259,7 +259,7 @@ cartStore.$subscribe((mutation, state) => {
 在底层实现上，`$subscribe()` 使用了 Vue 的 `watch()` 函数。你可以传入与 `watch()` 相同的选项。当你想要在 **每次** state 变化后立即触发订阅时很有用：
 
 ```ts{4}
-cartStore.$subscribe((state) => {
+cartStore.$subscribe((mutation, state) => {
   // 每当状态发生变化时，将整个 state 持久化到本地存储
   localStorage.setItem('cart', JSON.stringify(state))
 }, { flush: 'sync' })


### PR DESCRIPTION
en document
<img width="551" height="241" alt="en documebnt" src="https://github.com/user-attachments/assets/816828ab-d204-4a51-ad6e-3ae699d012d8" />

zh document
<img width="545" height="223" alt="zh document" src="https://github.com/user-attachments/assets/5a3fea30-fbc8-435f-b417-3208398b800a" />

