### PR TITLE
Mention nuxt 4 in docs

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -5,7 +5,7 @@
   title="Learn about SSR best practices"
 />
 
-Using Pinia with [Nuxt](https://nuxt.com/) is easier since Nuxt takes care of a lot of things when it comes to _server side rendering_. For instance, **you don't need to care about serialization nor XSS attacks**. Pinia supports Nuxt Bridge and Nuxt 3. For bare Nuxt 2 support, [see below](#nuxt-2-without-bridge).
+Using Pinia with [Nuxt](https://nuxt.com/) is easier since Nuxt takes care of a lot of things when it comes to _server side rendering_. For instance, **you don't need to care about serialization nor XSS attacks**. Pinia supports Nuxt Bridge, Nuxt 3 and Nuxt 4. For bare Nuxt 2 support, [see below](#nuxt-2-without-bridge).
 
 <RuleKitLink />
 


### PR DESCRIPTION
Mentioned Nuxt 4 in the docs, since its already supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect compatibility with Nuxt 4, clarifying that Pinia supports Nuxt Bridge, Nuxt 3, and Nuxt 4. This helps users on the latest Nuxt version understand support status and setup expectations. No code, behavior, or API changes included. Content remains otherwise unchanged and is limited to docs only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->