### PR TITLE
fix(nuxt): resolve auto-imports in layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     ]
   },
   "resolutions": {
-    "@nuxt/kit": "^3.9.0",
     "@nuxt/schema": "^3.9.0"
   },
   "pnpm": {

--- a/packages/nuxt/playground/layers/layer-domain/nuxt.config.ts
+++ b/packages/nuxt/playground/layers/layer-domain/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/packages/nuxt/playground/layers/layer-domain/stores/basic.ts
+++ b/packages/nuxt/playground/layers/layer-domain/stores/basic.ts
@@ -1,0 +1,5 @@
+export const useBasicStore = defineStore('layer-basic', () => {
+  const count = ref(0)
+
+  return { count }
+})

--- a/packages/nuxt/playground/pages/index.vue
+++ b/packages/nuxt/playground/pages/index.vue
@@ -5,7 +5,7 @@ const counter = useCounter()
 
 useTestStore() // ~/domain/one/stores/testStore.ts
 useSomeStoreStore() // ~/stores/nested/some-stores.ts
-useBasicStore() // ~~/layers/layer-domain/stores/basic.ts
+const layerStore = useBasicStore() // ~~/layers/layer-domain/stores/basic.ts
 
 // await useAsyncData('counter', () => counter.asyncIncrement().then(() => true))
 
@@ -18,5 +18,7 @@ if (import.meta.server) {
   <div>
     <p>Count: {{ counter.$state.count }}</p>
     <button @click="counter.increment()">+</button>
+
+    <p>Layer store: {{ layerStore.count }}</p>
   </div>
 </template>

--- a/packages/nuxt/playground/pages/index.vue
+++ b/packages/nuxt/playground/pages/index.vue
@@ -3,8 +3,9 @@
 
 const counter = useCounter()
 
-useTestStore()
-useSomeStoreStore()
+useTestStore() // ~/domain/one/stores/testStore.ts
+useSomeStoreStore() // ~/stores/nested/some-stores.ts
+useBasicStore() // ~~/layers/layer-domain/stores/basic.ts
 
 // await useAsyncData('counter', () => counter.asyncIncrement().then(() => true))
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -7,6 +7,7 @@ import {
   addImports,
   createResolver,
   addImportsDir,
+  getLayerDirectories,
 } from '@nuxt/kit'
 import type { NuxtModule } from '@nuxt/schema'
 import { fileURLToPath } from 'node:url'
@@ -73,8 +74,14 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     }
 
     if (options.storesDirs) {
+      const layers = getLayerDirectories(nuxt)
+
       for (const storeDir of options.storesDirs) {
         addImportsDir(resolve(nuxt.options.rootDir, storeDir))
+
+        for (const layer of layers) {
+          addImportsDir(resolve(layer.app, storeDir))
+        }
       }
     }
   },

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -77,8 +77,6 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
       const layers = getLayerDirectories(nuxt)
 
       for (const storeDir of options.storesDirs) {
-        addImportsDir(resolve(nuxt.options.rootDir, storeDir))
-
         for (const layer of layers) {
           addImportsDir(resolve(layer.app, storeDir))
         }

--- a/packages/nuxt/test/nuxt.spec.ts
+++ b/packages/nuxt/test/nuxt.spec.ts
@@ -33,4 +33,8 @@ describe('Nuxt', async () => {
     expect(html).not.toContain('I should not be serialized or hydrated')
     expect(html).toContain('skipHydrate-wrapped state is correct')
   })
+
+  it('can auto import from layers', async () => {
+    expect(await $fetch('/')).toContain('Layer store: 0')
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@nuxt/kit': ^3.9.0
   '@nuxt/schema': ^3.9.0
 
 importers:
@@ -139,7 +138,7 @@ importers:
   packages/nuxt:
     dependencies:
       '@nuxt/kit':
-        specifier: ^3.9.0
+        specifier: ^3.20.0
         version: 3.20.0(magicast@0.5.1)
     devDependencies:
       '@nuxt/module-builder':
@@ -968,6 +967,10 @@ packages:
 
   '@nuxt/kit@3.20.0':
     resolution: {integrity: sha512-EoF1Gf0SPj9vxgAIcGEH+a4PRLC7Dwsy21K6f5+POzylT8DgssN8zL5pwXC+X7OcfzBrwYFh7mM7phvh7ubgeg==}
+    engines: {node: '>=18.12.0'}
+
+  '@nuxt/kit@4.2.0':
+    resolution: {integrity: sha512-1yN3LL6RDN5GjkNLPUYCbNRkaYnat6hqejPyfIBBVzrWOrpiQeNMGxQM/IcVdaSuBJXAnu0sUvTKXpXkmPhljg==}
     engines: {node: '>=18.12.0'}
 
   '@nuxt/module-builder@1.0.2':
@@ -4355,7 +4358,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.0:
@@ -5979,7 +5981,7 @@ snapshots:
   '@dxup/nuxt@0.1.1(magicast@0.5.1)':
     dependencies:
       '@dxup/unimport': 0.1.1
-      '@nuxt/kit': 3.20.0(magicast@0.5.1)
+      '@nuxt/kit': 4.2.0(magicast@0.5.1)
       chokidar: 4.0.3
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -6461,6 +6463,31 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@4.2.0(magicast@0.5.1)':
+    dependencies:
+      c12: 3.3.1(magicast@0.5.1)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.7
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ufo: 1.6.1
+      unctx: 2.4.1
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/module-builder@1.0.2(@nuxt/cli@3.30.0(magicast@0.5.1))(@vue/compiler-core@3.5.22)(esbuild@0.25.12)(typescript@5.9.3)(vue-tsc@3.1.3(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@nuxt/cli': 3.30.0(magicast@0.5.1)
@@ -6575,7 +6602,7 @@ snapshots:
 
   '@nuxt/test-utils@3.20.1(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@20.0.10)(magicast@0.5.1)(typescript@5.9.3)(vitest@3.2.4)':
     dependencies:
-      '@nuxt/kit': 3.20.0(magicast@0.5.1)
+      '@nuxt/kit': 4.2.0(magicast@0.5.1)
       c12: 3.3.1(magicast@0.5.1)
       consola: 3.4.2
       defu: 6.1.4


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

**Other information:**

- This is a continuation of https://github.com/vuejs/pinia/pull/2757 and https://github.com/vuejs/pinia/pull/2828 which can be resolved after this.
- Special thanks to @danielroe for implementing and shipping support for `getLayerDirectories` so quickly
- @posva couple of quick things:
  - I noticed the Nuxt dependencies are currently on v3. Lemme know if you'd like me to fly in a PR to upgrade those to v4 :)
  - I saw that `@nuxt/kit` was globally overridden in the monorepo workspace package.json. I'm not entirely sure why that was there in the first place, so that needs some extra review caution 🙏🏻 
  - I didn't spot any existing test suites for the Nuxt package, so just another layer to the playground as a way to manually test.

Fixes #3028
Closes #2757
Closes #2828 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for organizing Pinia stores within application layers.
  * UI now displays the layer store count on the homepage.

* **Chores**
  * Module updated to automatically discover and import stores from layer directories, improving modular app structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->