### PR TITLE
feat: update vueschool banner script url for adblocker prevention

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -96,7 +96,7 @@ export const sharedConfig = defineConfig({
     [
       'script',
       {
-        src: 'https://vueschool.io/banner.js?affiliate=pinia&type=top',
+        src: 'https://media.bitterbrains.com/main.js?from=pinia&type=top',
         // @ts-expect-error: vitepress bug
         async: true,
         type: 'text/javascript',


### PR DESCRIPTION
This PR is to update Vue School Banner script to https://media.bitterbrains.com/main.js to prevent adblockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the top banner on the documentation site to load from a new script source while keeping async behavior. No visual changes expected; improves reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->