### PR TITLE
Added note about new location for "stores" folder in Nuxt 4.

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -90,7 +90,7 @@ By default `@pinia/nuxt` exposes a few auto imports:
 - `storeToRefs()` when you need to extract individual refs from a store
 - `acceptHMRUpdate()` for [hot module replacement](../cookbook/hot-module-replacement.md)
 
-It also automatically imports **all stores** defined within your `stores` folder. It doesn't lookup for nested stores though. You can customize this behavior by setting the `storesDirs` option:
+It also automatically imports **all stores** defined within your `stores` folder (note that in Nuxt 4, this folder has been moved from the project root directory to the `app` directory). It doesn't lookup for nested stores though. You can customize this behavior by setting the `storesDirs` option:
 
 ```ts
 // nuxt.config.ts

--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -90,7 +90,7 @@ By default `@pinia/nuxt` exposes a few auto imports:
 - `storeToRefs()` when you need to extract individual refs from a store
 - `acceptHMRUpdate()` for [hot module replacement](../cookbook/hot-module-replacement.md)
 
-It also automatically imports **all stores** defined within your `stores` folder (note that in Nuxt 4, this folder has been moved from the project root directory to the `app` directory). It doesn't lookup for nested stores though. You can customize this behavior by setting the `storesDirs` option:
+It also automatically imports **all stores** defined within your `stores` folder (`app/stores` in Nuxt 4). It doesn't lookup for nested stores though. You can customize this behavior by setting the `storesDirs` option:
 
 ```ts
 // nuxt.config.ts


### PR DESCRIPTION
Minor documentation update noting that in Nuxt 4, the default `stores` folder has been moved to the `app` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Auto imports note for Nuxt 4: stores are located in the app/stores directory (not project root).
  * Helps users find and auto-import stores correctly when migrating or setting up Nuxt 4 projects.
  * Documentation-only update; no behavioral or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->