### PR TITLE
Fix spelling in composing-stores.md

### DIFF
--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -4,7 +4,7 @@
 
 Composing stores is about having stores that use each other, and this is supported in Pinia. There is one rule to follow:
 
-If **two or more stores use each other**, they cannot create an infinite loop through _getters_ or _actions_. They cannot **both** directly read each other state in their setup function:
+If **two or more stores use each other**, they cannot create an infinite loop through _getters_ or _actions_. They cannot **both** directly read each other's state in their setup function:
 
 ```js
 const useX = defineStore('x', () => {


### PR DESCRIPTION
fixes spelling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a grammatical error in the cookbook topic on composing stores, updating wording for proper possessive form to enhance clarity and readability.
  * This is a text-only update; no code, behavior, API, configuration, or example changes.
  * Readers should find the guidance easier to understand with more polished language.
  * No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->