### PR TITLE
Update composing-stores.md

### DIFF
--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -55,16 +55,17 @@ import { apiPurchase } from './api'
 
 export const useCartStore = defineStore('cart', () => {
   const user = useUserStore()
+  const list = ref([])
 
   const summary = computed(() => {
-    return `Hi ${user.name}, you have ${user.list.length} items in your cart. It costs ${price.value}.`
+    return `Hi ${user.name}, you have ${list.value.length} items in your cart. It costs ${price.value}.`
   })
 
   function purchase() {
-    return apiPurchase(user.id, user.list)
+    return apiPurchase(user.id, list.value)
   }
 
-  return { summary, purchase }
+  return { list, summary, purchase }
 })
 ```
 

--- a/packages/docs/cookbook/composing-stores.md
+++ b/packages/docs/cookbook/composing-stores.md
@@ -55,14 +55,13 @@ import { apiPurchase } from './api'
 
 export const useCartStore = defineStore('cart', () => {
   const user = useUserStore()
-  const list = ref([])
 
   const summary = computed(() => {
-    return `Hi ${user.name}, you have ${list.value.length} items in your cart. It costs ${price.value}.`
+    return `Hi ${user.name}, you have ${user.list.length} items in your cart. It costs ${price.value}.`
   })
 
   function purchase() {
-    return apiPurchase(user.id, list.value)
+    return apiPurchase(user.id, user.list)
   }
 
   return { summary, purchase }


### PR DESCRIPTION
According to "https://pinia.vuejs.org/core-concepts/#Setup-Stores", it claimed that  "you must return all state properties in setup stores for Pinia to pick them up as state." Anyway, this code broke that rule , I believe is a typo, hence I "put" the `list` ref back into the user store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the composing stores guide to show the cart example returning a list alongside summary and purchase.
  - Examples now reference a single source of truth for list data, improving clarity and consistency.
  - Clarified how list length and data are derived to better match real usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->