### PR TITLE
docs(core): explain how to create dynamic store instances using defin…

### DIFF
--- a/packages/docs/core-concepts/index.md
+++ b/packages/docs/core-concepts/index.md
@@ -171,3 +171,35 @@ const { name, doubleCount } = storeToRefs(store)
 const { increment } = store
 </script>
 ```
+
+## Dynamic Store IDs
+
+In some cases, you may want multiple independent instances of the same store (e.g. one per document, chat room, or session). You can do this by generating a dynamic store ID:
+
+```ts
+export const useBroadcastStore = (id?: string) =>
+  defineStore(`BroadcastStore-${id}`, {
+    state: () => ({ messages: [] }),
+    actions: {
+      addMessage(msg) {
+        this.messages.push(msg)
+      },
+    },
+  })()
+```
+
+Each call creates an independent store:
+
+```ts
+const roomA = useBroadcastStore('a')
+const roomB = useBroadcastStore('b')
+
+roomA.addMessage('Hello A')
+roomB.addMessage('Hello B')
+
+console.log(roomA.messages) // ['Hello A']
+console.log(roomB.messages) // ['Hello B']
+```
+
+This pattern allows for unique, isolated stores that share the same structure.
+


### PR DESCRIPTION
### ✨ Description

This PR adds a concise section demonstrating how to create **dynamic Pinia store instances** using unique IDs with `defineStore()`.  
It introduces a practical pattern like:

```ts
export const useBroadcastStore = (id?: string) =>
  defineStore(`BroadcastStore-${id}`, {
    state: () => ({ messages: [] }),
    actions: {
      addMessage(msg) {
        this.messages.push(msg)
      },
    },
  })()
```

Each call to `useBroadcastStore(id)` returns an independent store instance that shares the same structure but maintains its own state.

---

### Why

* Clarifies that store IDs can be generated dynamically.
* Documents a widely used but previously undocumented pattern.
* Keeps the example short and aligned with the existing tone of the **Defining a Store** section.

---

### Example Use Cases

* Multiple chat rooms or broadcast channels
* One store per open document or tab
* Isolated stores for multi-session dashboards

---

### Summary

This addition enhances the **Defining a Store** guide by showing how to use `defineStore()` dynamically to create multiple independent store instances with shared logic — a common need in real-world applications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive "Dynamic Store IDs" guide covering per-instance store creation with dynamically generated identifiers, enabling isolated state management for multiple store instances
  * Includes detailed code examples demonstrating how to create and manage independent stores with completely separate state, actions, and data isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->