### PR TITLE
refactor: types from 'any' to 'unknown' 

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinia/nuxt",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Nuxt Module for pinia",
   "keywords": [
     "pinia",

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Intuitive, type safe and flexible Store for Vue",
   "type": "module",
   "main": "index.cjs",

--- a/packages/pinia/src/hmr.ts
+++ b/packages/pinia/src/hmr.ts
@@ -16,7 +16,7 @@ import {
  * @param fn - object to test
  * @returns true if `fn` is a StoreDefinition
  */
-export const isUseStore = (fn: any): fn is StoreDefinition => {
+export const isUseStore = (fn: unknown): fn is StoreDefinition 
   return typeof fn === 'function' && typeof fn.$id === 'string'
 }
 
@@ -30,9 +30,9 @@ export const isUseStore = (fn: any): fn is StoreDefinition => {
  * @returns - newState
  */
 export function patchObject(
-  newState: Record<string, any>,
-  oldState: Record<string, any>
-): Record<string, any> {
+  newState: Record<string, unknown>,
+  oldState: Record<string, unknown>
+): Record<string, unknown> {
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in oldState) {
     const subPatch = oldState[key]
@@ -79,12 +79,12 @@ export function acceptHMRUpdate<
   S extends StateTree = StateTree,
   G extends _GettersTree<S> = _GettersTree<S>,
   A = _ActionsTree,
->(initialUseStore: StoreDefinition<Id, S, G, A>, hot: any) {
+>(initialUseStore: StoreDefinition<Id, S, G, A>, hot: unknown) {
   // strip as much as possible from iife.prod
   if (!__DEV__) {
     return () => {}
   }
-  return (newModule: any) => {
+  return (newModule: unknown) => {
     const pinia: Pinia | undefined = hot.data.pinia || initialUseStore._pinia
 
     if (!pinia) {

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -11,14 +11,13 @@ import { Pinia } from './rootStore'
 /**
  * Generic state of a Store
  */
-export type StateTree = Record<PropertyKey, any>
+export type StateTree = Record<PropertyKey, unknown>
 
 export function isPlainObject<S extends StateTree>(
   value: S | unknown
 ): value is S
 export function isPlainObject(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  o: any
+  o: unknown
 ): o is StateTree {
   return (
     o &&

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinia/testing",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Testing module for Pinia",
   "keywords": [
     "vue",


### PR DESCRIPTION
Refactor types from 'any' to 'unknown' 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across the library (stricter typings for store state, object checks, and HMR-related APIs) to enhance IDE support and catch more issues at compile time without changing runtime behavior.
* **Chores**
  * Package versions bumped: pinia to 3.0.5 and nuxt integration to 0.11.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->