### PR TITLE
feat(dx): warn when storeToRefs is called with a plain object

### DIFF
--- a/packages/pinia/__tests__/storeToRefs.spec.ts
+++ b/packages/pinia/__tests__/storeToRefs.spec.ts
@@ -200,6 +200,16 @@ describe('storeToRefs', () => {
     expect(spy).toHaveBeenCalledTimes(0)
   })
 
+  it('warns if a plain object is passed', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    storeToRefs({} as any)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('storeToRefs() expects a Pinia store')
+    )
+    spy.mockRestore()
+  })
+
   tds(() => {
     const store1 = defineStore('a', () => {
       const n = ref(0)

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -87,6 +87,12 @@ export type StoreToRefs<SS extends StoreGeneric> =
 export function storeToRefs<SS extends StoreGeneric>(
   store: SS
 ): StoreToRefs<SS> {
+  if (__DEV__ && !isRef(store) && !isReactive(store) && !('$id' in store)) {
+    console.warn(
+      `[🍍]: storeToRefs() expects a Pinia store but got a plain object.`
+    )
+  }
+
   const rawStore = toRaw(store)
 
   const refs = {} as StoreToRefs<SS>


### PR DESCRIPTION
### Linked Issue
Fixes: #3074

### Description

This PR adds a development-only warning when `storeToRefs()` is called with a plain object instead of a Pinia store or a reactive object. This is a common beginner mistake and currently fails silently, producing refs that are not reactive. Adding a warning improves DX by immediately pointing out the misuse.

### What it handles

Example of incorrect usage:

```ts
const useCounter = defineStore('counter', { state: () => ({ count: 0 }) })
const counter = useCounter()

// ❌ not a store instance
const { count } = storeToRefs({ count: counter.count })
```

This returns a ref that is not connected to the actual store state.

This PR adds a minimal `__DEV__` check to detect this case and show a warning:

- If the input has no `$id`
- And is not a ref
- And is not reactive

### Tests

Added a test in `packages/pinia/__tests__/storeToRefs.spec.ts`:

```ts
it('warns if a plain object is passed', () => {
  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
  storeToRefs({} as any)
  expect(spy).toHaveBeenCalledTimes(1)
  spy.mockRestore()
})
```



### Safety

- This is **purely dev-only** (`__DEV__` block)
- No breaking changes
- No behavioral changes in production
- Fully backward-compatible

Happy to update anything based on feedback!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case validating storeToRefs warning behavior.

* **New Features**
  * storeToRefs now displays a console warning when called with invalid input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->