### PR TITLE
docs: fix typos in types and documentation

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -286,7 +286,7 @@ const store = mockedStore(useSomeStore)
 store.someAction.mockResolvedValue('some value')
 ```
 
-If you are interesting in learning more tricks like this, you should check out the Testing lessons on [Mastering Pinia](https://masteringpinia.com/lessons/exercise-mocking-stores-introduction).
+If you are interested in learning more tricks like this, you should check out the Testing lessons on [Mastering Pinia](https://masteringpinia.com/lessons/exercise-mocking-stores-introduction).
 
 ### Specifying the createSpy function
 

--- a/packages/docs/core-concepts/actions.md
+++ b/packages/docs/core-concepts/actions.md
@@ -192,7 +192,7 @@ const unsubscribe = someStore.$onAction(
     console.log(`Start "${name}" with params [${args.join(', ')}].`)
 
     // this will trigger if the action succeeds and after it has fully run.
-    // it waits for any returned promised
+    // it waits for any returned promise
     after((result) => {
       console.log(
         `Finished "${name}" after ${

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -366,7 +366,7 @@ export interface _StoreWithState<
    * On top of these, it receives two functions that allow setting up a callback
    * once the action finishes or when it fails.
    *
-   * It also returns a function to remove the callback. Note than when calling
+   * It also returns a function to remove the callback. Note that when calling
    * `store.$onAction()` inside of a component, it will be automatically cleaned
    * up when the component gets unmounted unless `detached` is set to true.
    *


### PR DESCRIPTION
## Summary
This PR fixes 3 minor typos found in the codebase addressing #3081 :

### Changes
1. **packages/pinia/src/types.ts** (line 369): "Note than when" → "Note that when"
2. **packages/docs/cookbook/testing.md** (line 289): "If you are interesting" → "If you are interested"
3. **packages/docs/core-concepts/actions.md** (line 195): "returned promised" → "returned promise"

### Type of change
- [x] Documentation update (typo fixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar and spelling errors in documentation and code comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->