### PR TITLE
refactor: use Object.prototype.hasOwnProperty.call() for safety

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -88,13 +88,13 @@ function mergeReactiveObjects<
 
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!patchToApply.hasOwnProperty(key)) continue
+    if (!Object.prototype.hasOwnProperty.call(patchToApply, key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
-      target.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(target, key) &&
       !isRef(subPatch) &&
       !isReactive(subPatch)
     ) {

--- a/packages/testing/src/testing.ts
+++ b/packages/testing/src/testing.ts
@@ -185,13 +185,13 @@ function mergeReactiveObjects<T extends StateTree>(
 ): T {
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!patchToApply.hasOwnProperty(key)) continue
+    if (!Object.prototype.hasOwnProperty.call(patchToApply, key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
-      target.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(target, key) &&
       !isRef(subPatch) &&
       !isReactive(subPatch)
     ) {


### PR DESCRIPTION
## Summary

This PR replaces direct `obj.hasOwnProperty(key)` calls with the safer `Object.prototype.hasOwnProperty.call(obj, key)` pattern.
fixes #3083 
### Why?

Calling `hasOwnProperty` directly on an object can fail if:
- The object was created with `Object.create(null)` (no prototype)
- The object has a property named `hasOwnProperty` that shadows the method

The codebase already uses the safe pattern in `shouldHydrate()` function. This PR applies the same pattern consistently to the `mergeReactiveObjects()` function in both:

### Changes
- **packages/pinia/src/store.ts**: 2 occurrences fixed
- **packages/testing/src/testing.ts**: 2 occurrences fixed

### Type of change
- [x] Refactor (no functional changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property validation robustness in core modules to handle edge cases with custom object prototypes, ensuring more reliable behavior with complex object structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->