### PR TITLE
refactor: Add `#__PURE__` annotation to `hotState`

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -279,7 +279,7 @@ function createSetupStore<
     pinia.state.value[$id] = {}
   }
 
-  const hotState = ref({} as S)
+  const hotState = /*#__PURE__*/ ref({} as S)
 
   // avoid triggering too many listeners
   // https://github.com/vuejs/pinia/issues/1129


### PR DESCRIPTION
`hotState` is only used during dev, but the call to `ref({})` wasn't being tree-shaken in production builds.

I've already partially addressed this in Vue core via <https://github.com/vuejs/core/pull/14308>, which adds `@__NO_SIDE_EFFECTS__` annotations to various functions, including `ref`. That will allow `hotState` to be tree-shaken in applications using the ESM bundler build of Pinia, but it doesn't help for the other builds.

When building a library, bundlers don't remove calls to functions marked `@__NO_SIDE_EFFECTS__` in external packages. I assume that's because they don't know which version of the external package will be used in the consuming application, and it's possible that some versions have `@__NO_SIDE_EFFECTS__` and some don't.

Using an explicit `#__PURE__` annotation in Pinia dodges that problem and allows it to be tree-shaken in all builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied compiler optimization hints to improve minification efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->