### PR TITLE
ci: avoid workflow failures for forks

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'vuejs/pinia'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The `pkg.pr.new` workflow shouldn't run for forks.

Similar to https://github.com/vuejs/router/pull/2497.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration with additional repository validation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->