### PR TITLE
refactor(types): remove Vue 2 type extensions

### DIFF
--- a/packages/pinia/src/globalExtensions.ts
+++ b/packages/pinia/src/globalExtensions.ts
@@ -1,38 +1,9 @@
 import type { Pinia } from './rootStore'
-import type { Store, StoreGeneric } from './types'
+import type { StoreGeneric } from './types'
 
 // Extensions of Vue types to be appended manually
 // https://github.com/microsoft/rushstack/issues/2090
 // https://github.com/microsoft/rushstack/issues/1709
-
-// @ts-ignore: works on Vue 2, fails in Vue 3
-declare module 'vue/types/vue' {
-  interface Vue {
-    /**
-     * Currently installed pinia instance.
-     */
-    $pinia: Pinia
-
-    /**
-     * Cache of stores instantiated by the current instance. Used by map
-     * helpers. Used internally by Pinia.
-     *
-     * @internal
-     */
-    _pStores?: Record<string, Store>
-  }
-}
-
-// @ts-ignore: works on Vue 2, fails in Vue 3
-declare module 'vue/types/options' {
-  interface ComponentOptions<V> {
-    /**
-     * Pinia instance to install in your application. Should be passed to the
-     * root Vue.
-     */
-    pinia?: Pinia
-  }
-}
 
 /**
  * NOTE: Used to be `@vue/runtime-core` but it break types from time to time. Then, in Vue docs, we started recommending


### PR DESCRIPTION
I believe these types are only relevant to Vue 2, so they can be removed from Pinia 3.

There is still a `@ts-ignore` on the `declare module 'vue'` (lines 13 & 14), which I haven't changed. It might be possible to remove that `@ts-ignore`, but I wasn't confident that'd be safe to change so I've left it in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed Vue 2-specific type augmentations
  * Simplified type imports and internal type definitions
  * Vue 3 API remains unchanged

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->