### PR TITLE
fix: use safe hasOwnProperty call when merging patches

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -88,13 +88,13 @@ function mergeReactiveObjects<
 
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!patchToApply.hasOwnProperty(key)) continue
+    if (!Object.prototype.hasOwnProperty.call(patchToApply, key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
-      target.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(target, key) &&
       !isRef(subPatch) &&
       !isReactive(subPatch)
     ) {


### PR DESCRIPTION
### What changed?

Replaced direct `patchToApply.hasOwnProperty()` usage with
`Object.prototype.hasOwnProperty.call()` inside `mergeReactiveObjects`.

### Why?

Calling `hasOwnProperty` directly can be unsafe if the object overrides the method.
Using the prototype call is the recommended safe approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code reliability through enhanced property access checks in the store module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->