### PR TITLE
Docs: fix invalid mapState example and magicValue usage

### DIFF
--- a/packages/docs/zh/core-concepts/state.md
+++ b/packages/docs/zh/core-concepts/state.md
@@ -151,7 +151,7 @@ export default {
   computed: {
     // 可以访问组件中的 this.count
     // 与从 store.count 中读取的数据相同
-    ...mapState(useCounterStore, ['count'])
+    ...mapState(useCounterStore, ['count']),
     // 与上述相同，但将其注册为 this.myOwnName
     ...mapState(useCounterStore, {
       myOwnName: 'count',
@@ -159,7 +159,7 @@ export default {
       double: store => store.count * 2,
       // 它可以访问 `this`，但它没有标注类型...
       magicValue(store) {
-        return store.someGetter + this.count + this.double
+        return store.someGetter + store.count + this.double
       },
     }),
   },


### PR DESCRIPTION
# This PR fixes two issues in the `mapState` example in `state.md`:

1. Add a missing trailing comma after `...mapState(...)` to avoid a syntax error when copying the example.
2. Fix `magicValue` to use `store.count` instead of `this.count`, which is not reliably defined on the component instance and causes runtime warnings.

## before fixed
<img width="3248" height="1944" alt="微信图片_20260210121223_4_377" src="https://github.com/user-attachments/assets/a8628fa6-b991-4068-8ef3-d79a03e1bf16" />
<img width="1454" height="1008" alt="微信图片_20260210121223_5_377" src="https://github.com/user-attachments/assets/7e1091a8-ff80-4f22-838a-0ff8a2879be0" />

## after fixed
<img width="1066" height="633" alt="image" src="https://github.com/user-attachments/assets/632acaba-8fd1-4d2e-a091-0eb0cec825a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Corrected code examples in the State Management documentation to improve accuracy and consistency of API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->