### PR TITLE
feat: add a context API for stores

### DIFF
--- a/packages/docs/core-concepts/store-context.md
+++ b/packages/docs/core-concepts/store-context.md
@@ -1,0 +1,141 @@
+# Passing context to stores
+
+<MasteringPiniaLink
+href="https://masteringpinia.com/lessons/What-is-a-pinia-plugin"
+title="Learn all about Pinia plugins"
+/>
+
+When building complex apps it can happen that you need to inject data or function
+in stores when they are first instanced.
+
+Context is added to the pinia instance with `pinia.provide()`. With it you can
+define a property of the context object that will be passed to the store when it
+is initialized.
+
+When using the setup API :
+
+```js
+import { createPinia, defineStore } from 'pinia'
+
+// add a property named `secret` to every store that is created
+// after this plugin is installed this could be in a different file
+const API_URL = 'https://localhost/blog/'
+
+const pinia = createPinia()
+// provide the contextual data
+pinia.provide('apiUrl', API_URL)
+
+// in your store declaration
+const useStore = defineStore('blog', ({ context }) => {
+  console.log(`API URL is ${context.apiUrl}`)
+  // logs "API URL is https://localhost/blog/"
+
+  return {
+    // your store's implementation
+  }
+})
+```
+
+When using the Option API :
+
+```js
+import { createPinia, defineStore } from 'pinia'
+
+const API_URL = 'https://localhost/blog/'
+
+const pinia = createPinia()
+// provide the contextual data to every store intantiations
+pinia.provide('apiUrl', API_URL)
+
+// in your store declaration
+const useStore = defineStore('blog', {
+  state: (context) => {
+    console.log(`API URL is ${context.apiUrl}`)
+    // logs "API URL is https://localhost/blog/"
+    return {
+      // your store's state
+    }
+  },
+})
+```
+
+## Changing the context value after the fact
+
+Context is only provided when the store is first initialized and is not reactive
+by default, if you pass in a value and modify it outside the store it will not
+be reflected inside of it unless you use references :
+
+```js
+import { createPinia, defineStore } from 'pinia'
+
+const api = {
+  url: 'https://localhost/blog/',
+}
+
+const pinia = createPinia()
+  // this can't be updated
+  .provide('api', api)
+  // but this can
+  .provide('apiUrl', api.url)
+
+api.url = 'https://example.com/blog/'
+
+// in your store declaration
+const useStore = defineStore('blog', (context) => {
+  console.log(`API URL is ${context.apiUrl}`)
+  // logs "API URL is https://localhost/blog/"
+
+  console.log(`API URL is ${context.api.url}`)
+  // logs "API URL is https://example.com/blog/"
+  return {
+    // your store's state
+  }
+})
+```
+
+## The context object is readonly
+
+When accessed in the store the context properties are readonly, you can add new
+ones (not advised) but you can't update the existing ones.
+
+```js
+import { createPinia, defineStore } from 'pinia'
+
+const pinia = createPinia().provide('api', 'https://localhost/blog/')
+
+// in your store declaration
+const useStore = defineStore('blog', (context) => {
+  context.api = 'https://example.com/blog/'
+  // this will throw a TypeError
+
+  return {
+    // your store's state
+  }
+})
+```
+
+## Typing the context data
+
+When adding new fields in the context object you should extend the
+`PiniaSetupContext` interface so calls to `.provide()` and access to properties
+on `context` are validated by TypeScript.
+
+```ts
+import 'pinia'
+
+interface MyLogger {
+  info(message: string): void
+  error(error: Error): void
+}
+
+declare module 'pinia' {
+  export interface PiniaSetupContext {
+    // type the context of the example above
+    apiUrl: string
+
+    // you can also pass in more complex things like functions or objects
+    sendMail: (message: string, to: string) => void
+    logger: MyLogger
+  }
+}
+```

--- a/packages/pinia/__tests__/storeContext.spec.ts
+++ b/packages/pinia/__tests__/storeContext.spec.ts
@@ -1,5 +1,101 @@
-import { it,  describe } from 'vitest';
+import { mount } from '@vue/test-utils'
+import { createPinia, defineStore } from 'pinia'
+import { it, describe, expect } from 'vitest'
 
-describe('storeContext.spec.ts', () => {
-	$END$
+const key = Symbol('key')
+declare module '../src' {
+  export interface PiniaSetupContext {
+    value: string
+    [key]: string
+  }
+}
+describe('store context injection', () => {
+  it('provides context to setup stores', async ({ task: { id } }) => {
+    const pinia = createPinia().provide('value', id).provide(key, id)
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    const useStore = defineStore('main', ({ context }) => {
+      return {
+        value: context.value,
+        key: context[key],
+      }
+    })
+
+    const store = useStore(pinia)
+
+    expect(store).toHaveProperty('value', id)
+    expect(store).toHaveProperty('key', id)
+  })
+
+  it('provides context to option state', ({ task: { id } }) => {
+    const pinia = createPinia().provide('value', id).provide(key, id)
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    const useStore = defineStore('main', {
+      state: (context) => ({
+        value: context.value,
+        key: context[key],
+      }),
+    })
+
+    const store = useStore(pinia)
+
+    expect(store).toHaveProperty('value', id)
+  })
+
+  it('is not writable', ({ task: { id } }) => {
+    const pinia = createPinia().provide('value', id).provide(key, id)
+
+    mount({ template: 'none' }, { global: { plugins: [pinia] } })
+
+    const useStore = defineStore('main', ({ context }) => {
+      let hasThrown = false
+
+      try {
+        // @ts-ignore we are making sure context is readonly
+        context.value = 'not writable'
+      } catch (e) {
+        hasThrown = true
+      }
+
+      return {
+        hasThrown,
+      }
+    })
+
+    const store = useStore(pinia)
+
+    expect(store).toHaveProperty('hasThrown', true)
+  })
+
+  it('has the same value for all store', ({ task: { id } }) => {
+    const pinia = createPinia().provide('value', id)
+
+    const useStoreA = defineStore('A', ({ context }) => {
+      return {
+        value: context.value,
+      }
+    })
+    const useStoreB = defineStore('A', ({ context }) => {
+      return {
+        value: context.value,
+      }
+    })
+
+    const storeA = useStoreA(pinia)
+    const storeB = useStoreB(pinia)
+
+    expect(storeA).toHaveProperty('value', id)
+    expect(storeB).toHaveProperty('value', id)
+  })
+
+  it('cannot provide the same key multiple times', () => {
+    const pinia = createPinia()
+      .provide('value', 'first')
+      .provide('value', 'second')
+
+    expect(pinia._i).toHaveProperty('value', 'first')
+  })
 })

--- a/packages/pinia/__tests__/storeContext.spec.ts
+++ b/packages/pinia/__tests__/storeContext.spec.ts
@@ -1,0 +1,5 @@
+import { it,  describe } from 'vitest';
+
+describe('storeContext.spec.ts', () => {
+	$END$
+})

--- a/packages/pinia/src/createPinia.ts
+++ b/packages/pinia/src/createPinia.ts
@@ -19,6 +19,9 @@ export function createPinia(): Pinia {
   // plugins added before calling app.use(pinia)
   let toBeInstalled: PiniaPlugin[] = []
 
+  // store context is empty by default
+  let _i: Pinia['_i'] = {} as Pinia['_i']
+
   const pinia: Pinia = markRaw({
     install(app: App) {
       // this allows calling useStore() outside of a component setup after
@@ -43,6 +46,22 @@ export function createPinia(): Pinia {
       }
       return this
     },
+    provide(key: string | symbol, value: unknown): Pinia {
+      if (key in _i) {
+        if (__DEV__) {
+          console.warn(
+            `[🍍]: Can't redefine injected property. Received ${String(key)} but it has already been registered, this is probably an error.`
+          )
+        }
+        return this
+      }
+      Object.defineProperty(_i, key, {
+        get() {
+          return value
+        },
+      })
+      return this
+    },
 
     _p,
     // it's actually undefined here
@@ -51,6 +70,7 @@ export function createPinia(): Pinia {
     _e: scope,
     _s: new Map<string, StoreGeneric>(),
     state,
+    _i,
   })
 
   // pinia devtools rely on dev only features so they cannot be forced unless

--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -3,7 +3,12 @@
  */
 export { setActivePinia, getActivePinia } from './rootStore'
 export { createPinia, disposePinia } from './createPinia'
-export type { Pinia, PiniaPlugin, PiniaPluginContext } from './rootStore'
+export type {
+  Pinia,
+  PiniaPlugin,
+  PiniaPluginContext,
+  PiniaSetupContext,
+} from './rootStore'
 
 export { defineStore, skipHydrate, shouldHydrate } from './store'
 export type {

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -59,6 +59,10 @@ export const getActivePinia = __DEV__
   : (): Pinia | undefined =>
       (hasInjectionContext() && inject(piniaSymbol)) || activePinia
 
+export interface PiniaSetupContext {
+  // context provided to stores by plugins will be available here
+  [unknownInjection: string | symbol]: unknown
+}
 /**
  * Every application must own its own pinia to be able to create stores
  */
@@ -76,6 +80,12 @@ export interface Pinia {
    * @param plugin - store plugin to add
    */
   use(plugin: PiniaPlugin): Pinia
+
+  provide(key: string | symbol, value: unknown): Pinia
+  provide<K extends keyof PiniaSetupContext>(
+    key: K,
+    value: PiniaSetupContext[K]
+  ): Pinia
 
   /**
    * Installed store plugins
@@ -111,6 +121,13 @@ export interface Pinia {
    * @internal
    */
   _testing?: boolean
+
+  /**
+   * Setup context passed to the setup function of setup store or the state function of option stores.
+   *
+   * @internal
+   */
+  _i: PiniaSetupContext
 }
 
 export const piniaSymbol = (
@@ -145,8 +162,51 @@ export interface PiniaPluginContext<
    * Initial options defining the store when calling `defineStore()`.
    */
   options: DefineStoreOptionsInPlugin<Id, S, G, A>
+
+  /**
+   * Make something available in the store setup function.
+   *
+   * @param key the name of the property used to access the provided value
+   * @param value the value to provide
+   */
+  provide: Provide
 }
 
+export interface Provide {
+  /**
+   * Make something available in the setup of stores.
+   *
+   * Augment PiniaSetupContext like so to enable strong typing.
+   * ```ts
+   * declare module 'pinia' {
+   * 	export interface PiniaSetupContext {
+   * 		myContextInjection: MyAwesomeType;
+   * 	}
+   * }
+   * ```
+   *
+   * @param key the key used to access the injected value. Can be a `string` or a `symbol`
+   * @param value the value to make available, can be anything but isn't reactive by default
+   */
+  <K extends keyof PiniaSetupContext>(key: K, value: PiniaSetupContext[K]): void
+
+  /**
+   * Make something available in the setup of stores.
+   *
+   * Augment PiniaSetupContext like so to enable strong typing.
+   * ```ts
+   * declare module 'pinia' {
+   * 	export interface PiniaSetupContext {
+   * 		myContextInjection: MyAwesomeType;
+   * 	}
+   * }
+   * ```
+   *
+   * @param key the key used to access the injected value. Can be a `string` or a `symbol`
+   * @param value the value to make available, can be anything but isn't reactive by default
+   */
+  (key: string | symbol, value: unknown): void
+}
 /**
  * Plugin to extend every store.
  */

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -46,7 +46,14 @@ import {
   _ExtractStateFromSetupStore,
   _StoreWithState,
 } from './types'
-import { setActivePinia, piniaSymbol, Pinia, activePinia } from './rootStore'
+import {
+  setActivePinia,
+  piniaSymbol,
+  Pinia,
+  activePinia,
+  PiniaSetupContext,
+  Provide,
+} from './rootStore'
 import { IS_CLIENT } from './env'
 import { patchObject } from './hmr'
 import { addSubscription, triggerSubscriptions, noop } from './subscriptions'
@@ -163,14 +170,14 @@ function createOptionsStore<
   function setup() {
     if (!initialState && (!__DEV__ || !hot)) {
       /* istanbul ignore if */
-      pinia.state.value[id] = state ? state() : {}
+      pinia.state.value[id] = state ? state(pinia._i) : {}
     }
 
     // avoid creating a state in pinia.state.value
     const localState =
       __DEV__ && hot
         ? // use ref() to unwrap refs inside state TODO: check if this is still necessary
-          toRefs(ref(state ? state() : {}).value)
+          toRefs(ref(state ? state(pinia._i) : {}).value)
         : toRefs(pinia.state.value[id])
 
     return assign(
@@ -329,7 +336,9 @@ function createSetupStore<
   const $reset = isOptionsStore
     ? function $reset(this: _StoreWithState<Id, S, G, A>) {
         const { state } = options as DefineStoreOptions<Id, S, G, A>
-        const newState: _DeepPartial<UnwrapRef<S>> = state ? state() : {}
+        const newState: _DeepPartial<UnwrapRef<S>> = state
+          ? state(pinia._i)
+          : {}
         // we use a patch to group all changes into one single subscription
         this.$patch(($state) => {
           // @ts-expect-error: FIXME: shouldn't error?
@@ -488,7 +497,10 @@ function createSetupStore<
 
   // TODO: idea create skipSerialize that marks properties as non serializable and they are skipped
   const setupStore = runWithContext(() =>
-    pinia._e.run(() => (scope = effectScope()).run(() => setup({ action }))!)
+    pinia._e.run(
+      () =>
+        (scope = effectScope()).run(() => setup({ action, context: pinia._i }))!
+    )
   )!
 
   // overwrite existing actions to support $onAction
@@ -690,6 +702,8 @@ function createSetupStore<
     )
   }
 
+  const provide: Provide = (key: string | symbol, value: unknown) =>
+    (pinia._i[key] = value)
   // apply all plugins
   pinia._p.forEach((extender) => {
     /* istanbul ignore else */
@@ -700,6 +714,7 @@ function createSetupStore<
           app: pinia._a,
           pinia,
           options: optionsForPlugin,
+          provide,
         })
       )!
       Object.keys(extensions || {}).forEach((key) =>
@@ -715,6 +730,7 @@ function createSetupStore<
             app: pinia._a,
             pinia,
             options: optionsForPlugin,
+            provide,
           })
         )!
       )
@@ -789,6 +805,12 @@ export interface SetupStoreHelpers {
    * @param name - name of the action. Will be picked up by the store at creation
    */
   action: <Fn extends _Method>(fn: Fn, name?: string) => Fn
+  /**
+   * Make context available to store.
+   *
+   * Define properties in the context with `pinia.provide()`.
+   */
+  context: Readonly<PiniaSetupContext>
 }
 
 /**

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -6,7 +6,7 @@ import type {
   WatchOptions,
   WritableComputedRef,
 } from 'vue'
-import { Pinia } from './rootStore'
+import { Pinia, PiniaSetupContext } from './rootStore'
 
 /**
  * Generic state of a Store
@@ -625,7 +625,7 @@ export interface DefineStoreOptions<
    * Function to create a fresh state. **Must be an arrow function** to ensure
    * correct typings!
    */
-  state?: () => S
+  state?: (context: Readonly<PiniaSetupContext>) => S
 
   /**
    * Optional object of getters.


### PR DESCRIPTION
Myself and others (see #1611 ) have had the need to provide things to stores during the initialization process, be it configuration or dependencies to be used in the store implementation without using global variables.

This is intended to be a first draft of a new API, I don't expect this PR to be merged as is.

## Implementation

I'm proposing the following implementation to add this capability.

I didn't use the Plugin API because plugins are applied after stores are created, making it impossible to inject anything in the setup/state function.

API modifications :

- added a `.provide()` method on the Pinia instance
- added a `context` property on the `SetupStoreHelpers` object
- added a `context` argument to the `state` function of Option stores
- added a `PiniaSetupContext` interface

## Subtasks

- [x] add a test suite for the new API
- [x] add a page of documentation with examples
- [ ] add link to the documentation page (I'm not too sure where to place it)

## Considerations and doubts :

1. I made the properties on the context object read-only when defined via the `.provide()` function to prevent mutations of the shared context from within the stores, so it's possible to add new properties but not to edit existing ones. I decided not to use `Object.freeze` because it would require unfreezing at the start of each call to `.provide()`, which might have adverse effects on performance.
2. I print a warning message in DEV when calling `.provide()` multiple times with the same key and abort the edition, but I'm not sure if the value should not be overridden instead.
3. I could not get the pre-commit hook to work on my machine, so I ran the formatting command manually. Feel free to point out any automated action that I inadvertently skipped by doing so. (I can also rewrite the history to split my edits and the formatting changes if needed)

&nbsp;

## Summary by CodeRabbit

- **New Features**
  - Added `pinia.provide()` method to inject initialization-time data and functions into stores
  - Context is accessible in both setup and options API store definitions
  - Support for TypeScript typing via module augmentation for custom context fields
- **Documentation**
  - Added guide explaining context injection with examples for typing and usage patterns

&nbsp;