### PR TITLE
docs: fix installation instructions for nuxt pinia to include peer pinia

### DIFF
--- a/packages/docs/ssr/nuxt.md
+++ b/packages/docs/ssr/nuxt.md
@@ -13,6 +13,7 @@ Using Pinia with [Nuxt](https://nuxt.com/) is easier since Nuxt takes care of a 
 
 ```bash
 npx nuxi@latest module add pinia
+npm install pinia
 ```
 
 This will add both `@pinia/nuxt` and `pinia` to your project. **If you notice that `pinia` is not installed, please install it manually** with your package manager: `npm i pinia`.


### PR DESCRIPTION
# Fix of production issue

If you follow official instructions on https://pinia.vuejs.org/ssr/nuxt.html, only `@pinia/nuxt` is added to package.json and package lock (regardless of package). The problem is that since `@pinia/nuxt` expects `pinia` package as a peer dependency, it does not install it automatically, but expects it to be installed. Even tough, the vite resolves package in development server most of the time, production build of the code fails without any proper warning and the issue is quite difficult to trace down to pinia not being installed.

Therefore I believe that official instructions shall prompt user also to add `pinia` package, not only `@pinia/nuxt`. If it is considered even better alternative, warning may be added to explicitly inform users about the need to install `pinia` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nuxt installation instructions to explicitly include the core Pinia package installation step, providing clearer guidance for setting up Pinia with Nuxt projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->